### PR TITLE
fix: make build compatible with next.js

### DIFF
--- a/@remirror/core-extensions/package.json
+++ b/@remirror/core-extensions/package.json
@@ -17,6 +17,7 @@
   "main": "lib/index.js",
   "module": "lib/dist/core-extensions.esm.js",
   "peerDependencies": {
+    "@babel/runtime-corejs2": ">=7",
     "@types/prosemirror-commands": "^1.0.1",
     "@types/prosemirror-inputrules": "^1.0.2",
     "@types/prosemirror-model": "^1.7.0",

--- a/@remirror/core/package.json
+++ b/@remirror/core/package.json
@@ -5,6 +5,7 @@
   "author": "Ifiok Jr. <ifiokotung@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "@babel/runtime-corejs2": ">=7",
     "@emotion/core": "^10.0.9",
     "@types/memoize-one": "4.1.1",
     "@types/nanoevents": "1.0.0",

--- a/@remirror/core/package.json
+++ b/@remirror/core/package.json
@@ -34,9 +34,7 @@
     "prosemirror-view": "^1.8.4"
   },
   "devDependencies": {
-    "@types/lolex": "3.1.1",
-    "domino": "2.1.3",
-    "lolex": "3.1.0"
+    "domino": "2.1.3"
   },
   "files": [
     "lib",

--- a/@remirror/core/src/helpers/__tests__/base.spec.ts
+++ b/@remirror/core/src/helpers/__tests__/base.spec.ts
@@ -5,7 +5,6 @@ import {
   findMatches,
   format,
   isBoolean,
-  isClass,
   isDate,
   isEmptyArray,
   isEmptyObject,
@@ -89,13 +88,6 @@ describe('predicates', () => {
     const failValue = 'true';
     expect(isBoolean(passValue)).toBeTrue();
     expect(isBoolean(failValue)).toBeFalse();
-  });
-
-  it('isClass', () => {
-    const passValue = class Simple {};
-    const failValue = Function;
-    expect(isClass(passValue)).toBeTrue();
-    expect(isClass(failValue)).toBeFalse();
   });
 
   it('isDate', () => {

--- a/@remirror/core/src/helpers/__tests__/utils.spec.ts
+++ b/@remirror/core/src/helpers/__tests__/utils.spec.ts
@@ -13,7 +13,7 @@ import {
   tdEmpty,
   tr as row,
 } from 'jest-prosemirror';
-import lolex from 'lolex';
+import { omit } from '../base';
 import {
   cloneTransaction,
   equalNodeType,
@@ -202,23 +202,27 @@ describe('selectionEmpty', () => {
 });
 
 describe('cloneTransaction', () => {
-  let clock: lolex.InstalledClock<lolex.Clock>;
   beforeEach(() => {
-    clock = lolex.install();
+    jest.useFakeTimers();
   });
 
   afterEach(() => {
-    clock.uninstall();
+    jest.useRealTimers();
   });
 
-  it('clones the transaction', () => {
+  it('clones the transaction', done => {
     const {
       state: { tr },
     } = createEditor(doc(p()));
-    const clonedTr = cloneTransaction(tr);
-    expect(tr).toEqual(clonedTr);
-    clock.tick(500);
-    expect(tr).not.toEqual(cloneTransaction(tr));
+
+    setTimeout(() => {
+      const clonedTr = cloneTransaction(tr);
+      expect(omit(tr, ['time'])).toEqual(omit(clonedTr, ['time']));
+      expect(tr).not.toEqual(clonedTr);
+      done();
+    }, 10);
+
+    jest.advanceTimersByTime(20);
   });
 });
 

--- a/@remirror/core/src/helpers/base.ts
+++ b/@remirror/core/src/helpers/base.ts
@@ -321,6 +321,8 @@ export const isFunction = isOfType<AnyFunction>('function');
 export const isNull = (value: unknown): value is null => value === null;
 
 /**
+ * @deprecated Due to the current build process stripping out classes
+ *
  * Predicate check that value is a class
  *
  * @param value

--- a/@remirror/extension-emoji/package.json
+++ b/@remirror/extension-emoji/package.json
@@ -22,6 +22,7 @@
   "main": "lib/index.js",
   "module": "lib/dist/extension-emoji.esm.js",
   "peerDependencies": {
+    "@babel/runtime-corejs2": ">=7",
     "@types/prosemirror-model": "^1.7.0",
     "@types/prosemirror-state": "^1.2.3",
     "@types/prosemirror-view": "^1.3.1",

--- a/@remirror/extension-enhanced-link/package.json
+++ b/@remirror/extension-enhanced-link/package.json
@@ -14,6 +14,7 @@
   "main": "lib/index.js",
   "module": "lib/dist/extension-enhanced-link.esm.js",
   "peerDependencies": {
+    "@babel/runtime-corejs2": ">=7",
     "@types/prosemirror-state": "^1.2.3",
     "@types/prosemirror-transform": "^1.1.0",
     "prosemirror-state": "^1.2.2",

--- a/@remirror/extension-epic-mode/package.json
+++ b/@remirror/extension-epic-mode/package.json
@@ -15,6 +15,7 @@
   "main": "lib/index.js",
   "module": "lib/dist/extension-epic-mode.esm.js",
   "peerDependencies": {
+    "@babel/runtime-corejs2": ">=7",
     "@types/prosemirror-state": "^1.2.3",
     "prosemirror-state": "^1.2.2"
   },

--- a/@remirror/extension-mention/package.json
+++ b/@remirror/extension-mention/package.json
@@ -15,6 +15,7 @@
   "main": "lib/index.js",
   "module": "lib/dist/extension-mention.esm.js",
   "peerDependencies": {
+    "@babel/runtime-corejs2": ">=7",
     "@types/prosemirror-state": "^1.2.3",
     "@types/prosemirror-view": "^1.3.1",
     "prosemirror-state": "^1.2.2",

--- a/@remirror/react-ssr/package.json
+++ b/@remirror/react-ssr/package.json
@@ -22,6 +22,7 @@
   "main": "lib/index.js",
   "module": "lib/dist/react-ssr.esm.js",
   "peerDependencies": {
+    "@babel/runtime-corejs2": ">=7",
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0",
     "prosemirror-view": "1.8.3",

--- a/@remirror/react/package.json
+++ b/@remirror/react/package.json
@@ -24,6 +24,7 @@
   "main": "lib/index.js",
   "module": "lib/dist/react.esm.js",
   "peerDependencies": {
+    "@babel/runtime-corejs2": ">=7",
     "@emotion/core": "^10.0.7",
     "@types/prosemirror-commands": "^1.0.1",
     "@types/prosemirror-inputrules": "^1.0.2",

--- a/@remirror/renderer-react/package.json
+++ b/@remirror/renderer-react/package.json
@@ -19,6 +19,7 @@
   "main": "lib/index.js",
   "module": "lib/dist/renderer-react.esm.js",
   "peerDependencies": {
+    "@babel/runtime-corejs2": ">=7",
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0",
     "react": "^16.8.0",

--- a/@remirror/ui-twitter/package.json
+++ b/@remirror/ui-twitter/package.json
@@ -26,6 +26,7 @@
   "main": "lib/index.js",
   "module": "lib/dist/ui-twitter.esm.js",
   "peerDependencies": {
+    "@babel/runtime-corejs2": ">=7",
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0",
     "react": "^16.8.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
   "name": "root",
+  "browserslist": [
+    "> 1%",
+    "not dead"
+  ],
   "engines": {
     "node": ">=8"
   },

--- a/packages/jest-prosemirror/package.json
+++ b/packages/jest-prosemirror/package.json
@@ -35,6 +35,7 @@
   ],
   "main": "lib/index.js",
   "peerDependencies": {
+    "@babel/runtime-corejs2": ">=7",
     "jest": "^24.5.0"
   },
   "repository": {

--- a/packages/jest-remirror/package.json
+++ b/packages/jest-remirror/package.json
@@ -9,6 +9,7 @@
     "@remirror/core-extensions": "0.0.1-alpha.9",
     "@remirror/react": "0.0.1-alpha.9",
     "@remirror/renderer-react": "0.0.1-alpha.9",
+    "@types/lolex": "^3.1.1",
     "@types/prosemirror-model": "^1.7.0",
     "@types/prosemirror-view": "^1.3.1",
     "flatten": "^1.0.2",
@@ -31,6 +32,7 @@
   ],
   "main": "lib/index.js",
   "peerDependencies": {
+    "@babel/runtime-corejs2": ">=7",
     "@types/react": "^16.7.18",
     "@types/react-dom": "^16.8.0",
     "jest-snapshot": "^24.5.0",

--- a/packages/remirror/package.json
+++ b/packages/remirror/package.json
@@ -24,6 +24,7 @@
   "main": "lib/index.js",
   "module": "lib/dist/remirror.esm.js",
   "peerDependencies": {
+    "@babel/runtime-corejs2": ">=7",
     "@types/react": "^16.7.18",
     "@types/react-dom": "^16.8.0",
     "react": "^16.8.0",

--- a/support/babel/base.babel.js
+++ b/support/babel/base.babel.js
@@ -9,18 +9,7 @@ const ignore = [
 const nonTestEnv = { ignore };
 
 module.exports = {
-  presets: [
-    [
-      '@babel/preset-env',
-      {
-        targets: {
-          node: '8',
-        },
-      },
-    ],
-    '@babel/preset-typescript',
-    '@babel/preset-react',
-  ],
+  presets: [['@babel/preset-env'], '@babel/preset-typescript', '@babel/preset-react'],
   plugins: [
     '@babel/plugin-transform-typescript', // This is needed so that abstract classes are properly compiled
     '@babel/plugin-proposal-class-properties',

--- a/support/babel/base.babel.js
+++ b/support/babel/base.babel.js
@@ -12,6 +12,7 @@ module.exports = {
   presets: [['@babel/preset-env'], '@babel/preset-typescript', '@babel/preset-react'],
   plugins: [
     '@babel/plugin-transform-typescript', // This is needed so that abstract classes are properly compiled
+    ['@babel/plugin-transform-runtime', { corejs: 2 }],
     '@babel/plugin-proposal-class-properties',
     '@babel/plugin-proposal-object-rest-spread',
     '@babel/plugin-syntax-dynamic-import',

--- a/support/dependencies/package.json
+++ b/support/dependencies/package.json
@@ -9,6 +9,7 @@
     "@babel/plugin-proposal-class-properties": "7.4.0",
     "@babel/plugin-proposal-object-rest-spread": "7.4.0",
     "@babel/plugin-syntax-dynamic-import": "7.2.0",
+    "@babel/plugin-transform-runtime": "7.4.0",
     "@babel/plugin-transform-typescript": "7.4.0",
     "@babel/preset-env": "7.4.1",
     "@babel/preset-react": "7.0.0",

--- a/support/rollup/factory.js
+++ b/support/rollup/factory.js
@@ -81,6 +81,7 @@ function configure(pkg, env, target, rootFolder = '@remirror') {
       include: [`${rootFolder}/${folderName}/src/**`],
       extensions,
       exclude: ['node_modules/**', '*.json'],
+      runtimeHelpers: true,
     }),
 
     // Register Node.js globals for browserify compatibility.

--- a/yarn.lock
+++ b/yarn.lock
@@ -841,6 +841,16 @@
     resolve "^1.8.1"
     semver "^5.5.1"
 
+"@babel/plugin-transform-runtime@7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.0.tgz#b4d8c925ed957471bc57e0b9da53408ebb1ed457"
+  integrity sha512-1uv2h9wnRj98XX3g0l4q+O3jFM6HfayKup7aIu4pnnlzGz0H+cYckGBC74FZIWJXJSXAmeJ9Yu5Gg2RQpS4hWg==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    resolve "^1.8.1"
+    semver "^5.5.1"
+
 "@babel/plugin-transform-shorthand-properties@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz#6333aee2f8d6ee7e28615457298934a3b46198f0"
@@ -1092,6 +1102,14 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-transform-typescript" "^7.3.2"
+
+"@babel/runtime-corejs2@>=7":
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs2/-/runtime-corejs2-7.4.2.tgz#a0cec2c41717fa415e9c204f32b603d88b1796c2"
+  integrity sha512-y/Br/9uQnumcqcakkmobFqOTzYCWSS6Kuy1b2o7LTXR4lpeU0AhaOcPqIHW85LCxRWUDW5Vg0pU1KlE3YkORlg==
+  dependencies:
+    core-js "^2.6.5"
+    regenerator-runtime "^0.13.2"
 
 "@babel/runtime@7.0.0":
   version "7.0.0"
@@ -2536,7 +2554,7 @@
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.14.tgz#37daaf78069e7948520474c87b80092ea912520a"
   integrity sha512-Q5hTcfdudEL2yOmluA1zaSyPbzWPmJ3XfSWeP3RyoYvS9hnje1ZyagrZOuQ6+1nQC1Gw+7gap3pLNL3xL6UBug==
 
-"@types/lolex@3.1.1":
+"@types/lolex@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@types/lolex/-/lolex-3.1.1.tgz#d40895223e5c8f8aa64f5500c6ca4eeab067d432"
   integrity sha512-NU2qVtKxbt4IBvjEOW1QeUnV6KGUF6hpgJyvwZt3JrXe2qmwQF0+BiazQw+iFy9qL5ie+QHOxTzXkcvJUEh76g==
@@ -4801,7 +4819,7 @@ core-js@^1.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
   integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
-core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0, core-js@^2.5.7:
+core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0, core-js@^2.5.7, core-js@^2.6.5:
   version "2.6.5"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
   integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
@@ -9894,7 +9912,7 @@ loglevelnext@^1.0.1, loglevelnext@^1.0.2:
     es6-symbol "^3.1.1"
     object.assign "^4.1.0"
 
-lolex@3.1.0, lolex@^3.1.0:
+lolex@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-3.1.0.tgz#1a7feb2fefd75b3e3a7f79f0e110d9476e294434"
   integrity sha512-zFo5MgCJ0rZ7gQg69S4pqBsLURbFw11X68C18OcJjJQbqaXm2NoTrGl1IMM3TIz0/BnN1tIs2tzmmqvCsOMMjw==
@@ -12743,6 +12761,11 @@ regenerator-runtime@^0.12.0:
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
   integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
+
+regenerator-runtime@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
+  integrity sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==
 
 regenerator-transform@^0.13.3, regenerator-transform@^0.13.4:
   version "0.13.4"


### PR DESCRIPTION
## Description

- Removes `node: 8` from `@babel/preset-env` config
- Add `@babel/transform-runtime` to the build
- Add `"@babel/runtime-corejs2": ">=7"`  as a direct dependency of `@remirror/core` and a peer dependency of all other projects
- Fixes broken test and deprecates `isClass` utility which no longer makes sense since classes are compiled down to functions.
- Removes [`lolex`](https://github.com/sinonjs/lolex) as a test dependency which stopped working after changes made.
 

Fixes #59 

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/ifiokjr/remirror/blob/master/contributing.md) document.
