### PR TITLE
feat: remirror-manager supports child fragments

### DIFF
--- a/@remirror/react/src/components/__tests__/remirror-manager.spec.tsx
+++ b/@remirror/react/src/components/__tests__/remirror-manager.spec.tsx
@@ -93,10 +93,7 @@ describe('manager prop', () => {
 test('it supports <RemirrorExtension />', () => {
   const Component: FC = () => {
     const manager = useRemirrorManager();
-    expect(manager.extensions).toContainAnyValues([
-      expect.any(NewExtension),
-      expect.any(PlaceholderExtension),
-    ]);
+    expect(manager.extensions).toContainValues([expect.any(NewExtension), expect.any(PlaceholderExtension)]);
     return null;
   };
 
@@ -104,6 +101,24 @@ test('it supports <RemirrorExtension />', () => {
     <RemirrorManager>
       <Component />
       <RemirrorExtension Constructor={NewExtension} />
+      <RemirrorExtension Constructor={PlaceholderExtension} emptyNodeClass='empty' />
+    </RemirrorManager>,
+  );
+});
+
+test('it supports <RemirrorExtension /> in child fragments', () => {
+  const Component: FC = () => {
+    const manager = useRemirrorManager();
+    expect(manager.extensions).toContainValues([expect.any(NewExtension), expect.any(PlaceholderExtension)]);
+    return null;
+  };
+
+  render(
+    <RemirrorManager>
+      <Component />
+      <>
+        <RemirrorExtension Constructor={NewExtension} />
+      </>
       <RemirrorExtension Constructor={PlaceholderExtension} emptyNodeClass='empty' />
     </RemirrorManager>,
   );

--- a/@remirror/react/src/components/remirror-manager.tsx
+++ b/@remirror/react/src/components/remirror-manager.tsx
@@ -1,8 +1,13 @@
-import React, { Children, Component } from 'react';
+import React, { Children, Component, ReactNode } from 'react';
 
 import { ExtensionManager, isString, PrioritizedExtension } from '@remirror/core';
 import { baseExtensions, PlaceholderExtension } from '@remirror/core-extensions';
-import { asDefaultProps, isRemirrorExtension, RemirrorManagerProps } from '@remirror/react-utils';
+import {
+  asDefaultProps,
+  isReactFragment,
+  isRemirrorExtension,
+  RemirrorManagerProps,
+} from '@remirror/react-utils';
 import { RemirrorManagerContext } from '../contexts';
 
 export class RemirrorManager extends Component<RemirrorManagerProps> {
@@ -35,7 +40,18 @@ export class RemirrorManager extends Component<RemirrorManagerProps> {
    */
   public get manager(): ExtensionManager {
     const extensions: PrioritizedExtension[] = [...this.baseExtensions];
-    Children.forEach(this.props.children, child => {
+
+    const { children } = this.props;
+
+    const resolvedChildren = Children.toArray(children).reduce((acc: ReactNode[], child: ReactNode) => {
+      if (isReactFragment(child)) {
+        return [...acc, ...Children.toArray(child.props.children)];
+      } else {
+        return [...acc, child];
+      }
+    }, []);
+
+    resolvedChildren.forEach(child => {
       if (!isRemirrorExtension(child)) {
         return;
       }


### PR DESCRIPTION
This patch allows for better composition within `RemirrorManager` by
allowing loading extensions via child Fragments.

This lets (immediate) child components of RemirrorManager load extensions.

```jsx
<RemirrorManager>
  <Component />
  <>
    <RemirrorExtension Constructor={NewExtension} />
  </>
  <RemirrorExtension Constructor={PlaceholderExtension} emptyNodeClass='empty' />
</RemirrorManager>,
```