### PR TITLE
Fix imports of core-extensions in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ The following is an example editor which renders a floating menu and enables the
 import React, { FC, FunctionComponent, MouseEventHandler, useState } from 'react';
 
 import { memoize, EMPTY_OBJECT_NODE } from '@remirror/core';
-import { Bold, Italic, Underline } from '@remirror/core-extensions';
+import { BoldExtension, ItalicExtension, UnderlineExtension } from '@remirror/core-extensions';
 import {
   bubblePositioner,
   ManagedRemirrorProvider,


### PR DESCRIPTION
## Description

Fix imports of core-extensions in readme.md. 

Renames `Bold` to `BoldExtension`, `Underline` to `UnderlineExtension`, and `Italic` to `ItalicExtension`.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**CONTRIBUTING**](https://github.com/ifiokjr/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project 
- [ ] `yarn fix` runs successfully.
- [x] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `yarn test` .
