### PR TITLE
Fix imports of core-extensions in readme.md. 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ The following is an example editor which renders a floating menu and enables the
 import React, { FC, FunctionComponent, MouseEventHandler, useState } from 'react';
 
 import { memoize, EMPTY_OBJECT_NODE } from '@remirror/core';
-import { Bold, Italic, Underline } from '@remirror/core-extensions';
+import { BoldExtension, ItalicExtension, UnderlineExtension } from '@remirror/core-extensions';
 import {
   bubblePositioner,
   ManagedRemirrorProvider,

--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@
 yarn add @remirror/core @remirror/react @remirror/core-extensions
 ```
 
-The following is an example editor which renders a floating menu and enables the extensions `Bold`, `Italic` and `Underline`.
+The following is an example editor which renders a floating menu and enables the extensions `BoldExtension`, `ItalicExtension` and `UnderlineExtension`.
 
 ```ts
 import React, { FC, FunctionComponent, MouseEventHandler, useState } from 'react';
@@ -134,9 +134,9 @@ const SimpleFloatingMenu: FC = () => {
 const EditorLayout: FunctionComponent = () => {
   return (
     <RemirrorManager>
-      <RemirrorExtension Constructor={Bold} />
-      <RemirrorExtension Constructor={Italic} />
-      <RemirrorExtension Constructor={Underline} />
+      <RemirrorExtension Constructor={BoldExtension} />
+      <RemirrorExtension Constructor={ItalicExtension} />
+      <RemirrorExtension Constructor={UnderlineExtension} />
       <ManagedRemirrorProvider
         attributes={{ 'data-testid': 'editor-instance' }}
         onChange={onChange}
@@ -183,9 +183,9 @@ const EpicModeComponent: FC<EpicModeComponentProps> = ({ particleEffect, placeho
   return (
     <div>
       <RemirrorManager>
-        <RemirrorExtension Constructor={Bold} />
-        <RemirrorExtension Constructor={Italic} />
-        <RemirrorExtension Constructor={Underline} />
+        <RemirrorExtension Constructor={BoldExtension} />
+        <RemirrorExtension Constructor={ItalicExtension} />
+        <RemirrorExtension Constructor={UnderlineExtension} />
         <RemirrorExtension Constructor={EpicMode} particleEffect={particleEffect} shake={shake} />
         <ManagedRemirrorProvider
           autoFocus={true}


### PR DESCRIPTION
## Description

Fix imports of core-extensions in readme.md. 

Renames `Bold` to `BoldExtension`, `Underline` to `UnderlineExtension`, and `Italic` to `ItalicExtension`.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**CONTRIBUTING**](https://github.com/ifiokjr/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project 
- [ ] `yarn fix` runs successfully.
- [x] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `yarn test` .
