### PR TITLE
Docs update: rename EMPTY_OBJECT_NODE to EMPTY_PARAGRAPH_NODE

### DIFF
--- a/@remirror/react-utils/src/helpers.ts
+++ b/@remirror/react-utils/src/helpers.ts
@@ -71,7 +71,7 @@ export const uniqueClass = (uid: string, className: string) => `${className}-${u
  *
  * ```ts
  * static defaultProps = asDefaultProps<RemirrorProps>()({
- *   initialContent: EMPTY_OBJECT_NODE,
+ *   initialContent: EMPTY_PARAGRAPH_NODE,
  * });
  * ```
  */

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -71,7 +71,7 @@ The following is a small example which renders a floating menu and enables the e
 ```ts
 import React, { FC, FunctionComponent, MouseEventHandler, useState } from 'react';
 
-import { memoize, EMPTY_OBJECT_NODE } from '@remirror/core';
+import { memoize, EMPTY_PARAGRAPH_NODE } from '@remirror/core';
 import { Bold, Italic, Underline } from '@remirror/core-extensions';
 import {
   bubblePositioner,
@@ -149,7 +149,7 @@ const EditorLayout: FunctionComponent = () => {
         onChange={onChange}
         placeholder='Start typing for magic...'
         autoFocus={true}
-        initialContent={EMPTY_OBJECT_NODE}
+        initialContent={EMPTY_PARAGRAPH_NODE}
       >
         <SimpleFloatingMenu />
       </ManagedRemirrorProvider>

--- a/docs/install.mdx
+++ b/docs/install.mdx
@@ -14,7 +14,7 @@ The following is a small example which renders a floating menu and enables the e
 ```ts
 import React, { FC, FunctionComponent, MouseEventHandler, useState } from 'react';
 
-import { memoize, EMPTY_OBJECT_NODE } from '@remirror/core';
+import { memoize, EMPTY_PARAGRAPH_NODE } from '@remirror/core';
 import { Bold, Italic, Underline } from '@remirror/core-extensions';
 import {
   bubblePositioner,
@@ -92,7 +92,7 @@ const EditorLayout: FunctionComponent = () => {
         onChange={onChange}
         placeholder='Start typing for magic...'
         autoFocus={true}
-        initialContent={EMPTY_OBJECT_NODE}
+        initialContent={EMPTY_PARAGRAPH_NODE}
       >
         <SimpleFloatingMenu />
       </ManagedRemirrorProvider>

--- a/packages/remirror/readme.md
+++ b/packages/remirror/readme.md
@@ -36,7 +36,7 @@ The following is a small example which renders a floating menu and enables the e
 import React, { FC, FunctionComponent, MouseEventHandler, useState } from 'react';
 
 import {
-  EMPTY_OBJECT_NODE,
+  EMPTY_PARAGRAPH_NODE,
   Bold,
   Italic,
   Underline,
@@ -115,7 +115,7 @@ const EditorLayout: FunctionComponent = () => {
         onChange={onChange}
         placeholder='Start typing for magic...'
         autoFocus={true}
-        initialContent={EMPTY_OBJECT_NODE}
+        initialContent={EMPTY_PARAGRAPH_NODE}
       >
         <SimpleFloatingMenu />
       </ManagedRemirrorProvider>

--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,7 @@ The following is an example editor which renders a floating menu and enables the
 ```ts
 import React, { FC, FunctionComponent, MouseEventHandler, useState } from 'react';
 
-import { memoize, EMPTY_OBJECT_NODE } from '@remirror/core';
+import { memoize, EMPTY_PARAGRAPH_NODE } from '@remirror/core';
 import { BoldExtension, ItalicExtension, UnderlineExtension } from '@remirror/core-extensions';
 import {
   bubblePositioner,
@@ -142,7 +142,7 @@ const EditorLayout: FunctionComponent = () => {
         onChange={onChange}
         placeholder='Start typing for magic...'
         autoFocus={true}
-        initialContent={EMPTY_OBJECT_NODE}
+        initialContent={EMPTY_PARAGRAPH_NODE}
       >
         <SimpleFloatingMenu />
       </ManagedRemirrorProvider>


### PR DESCRIPTION
## Description

Rename EMPTY_OBJECT_NODE to EMPTY_PARAGRAPH_NODE in docs.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**CONTRIBUTING**](https://github.com/ifiokjr/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `yarn fix` runs successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `yarn test` .


## Test results

```
=============================== Coverage summary ===============================
Statements   : 69.03% ( 1995/2890 )
Branches     : 55.12% ( 813/1475 )
Functions    : 62.58% ( 612/978 )
Lines        : 69.38% ( 1928/2779 )
================================================================================
Test Suites: 42 passed, 42 total
Tests:       1 skipped, 409 passed, 410 total
Snapshots:   26 passed, 26 total
Time:        56.046s
Ran all test suites in 11 projects.```
