### PR TITLE
feat: ensure trailing paragraph

### DIFF
--- a/@remirror/core/src/extension.ts
+++ b/@remirror/core/src/extension.ts
@@ -489,8 +489,17 @@ export interface PrioritizedExtension {
 export type FlexibleExtension = PrioritizedExtension | AnyExtension;
 
 export interface ExtensionListParams {
-  /** A list of passed extensions */
+  /**
+   * A list of passed extensions
+   */
   extensions: AnyExtension[];
+}
+
+export interface ExtensionParams<GExtension extends AnyExtension = AnyExtension> {
+  /**
+   * An extension
+   */
+  extension: GExtension;
 }
 
 /**

--- a/@remirror/core/src/helpers/__tests__/utils.spec.ts
+++ b/@remirror/core/src/helpers/__tests__/utils.spec.ts
@@ -25,7 +25,7 @@ import {
   findSelectedNodeOfType,
   isNodeActive,
   nodeEqualsType,
-  removeNodeAtPos,
+  removeNodeAtPosition,
   removeNodeBefore,
   selectionEmpty,
   transactionChanged,
@@ -42,12 +42,12 @@ describe('nodeEqualsType', () => {
   });
 });
 
-describe('removeNodeAtPos', () => {
+describe('removeNodeAtPosition', () => {
   it('removes block top level nodes at specified position', () => {
     const {
       state: { tr },
     } = createEditor(doc(p('x'), p('one')));
-    const newTr = removeNodeAtPos(3)(tr);
+    const newTr = removeNodeAtPosition({ pos: 3, tr });
     expect(newTr).not.toBe(tr);
     expect(newTr.doc).toEqualPMNode(doc(p('x')));
   });
@@ -56,7 +56,7 @@ describe('removeNodeAtPos', () => {
     const {
       state: { tr },
     } = createEditor(doc(p('one', atomInline())));
-    const newTr = removeNodeAtPos(4)(tr);
+    const newTr = removeNodeAtPosition({ pos: 4, tr });
     expect(newTr).not.toBe(tr);
     expect(newTr.doc).toEqualPMNode(doc(p('one')));
   });

--- a/@remirror/core/src/helpers/__tests__/utils.spec.ts
+++ b/@remirror/core/src/helpers/__tests__/utils.spec.ts
@@ -14,11 +14,14 @@ import {
   tdEmpty,
   tr as row,
 } from 'jest-prosemirror';
-import { NodeSelection, TextSelection } from 'prosemirror-state';
+import { NodeSelection, Selection, TextSelection } from 'prosemirror-state';
 import { omit } from '../base';
 import {
   cloneTransaction,
   findElementAtPosition,
+  findNodeAtEndOfDoc,
+  findNodeAtSelection,
+  findNodeAtStartOfDoc,
   findParentNode,
   findParentNodeOfType,
   findPositionOfNodeBefore,
@@ -383,5 +386,29 @@ describe('findSelectedNodeOfType', () => {
     const selectedNode = findSelectedNodeOfType({ types: [paragraph, table], selection: tr.selection });
 
     expect(selectedNode!.node.type.name).toEqual('paragraph');
+  });
+});
+
+describe('findNodeAt...', () => {
+  const expectedEnd = h2('Heading here');
+  const expectedStart = p('<cursor> I am champion');
+  const pmDoc = doc(expectedStart, expectedEnd);
+
+  test('findNodeAtSelection', () => {
+    const selection = Selection.atEnd(pmDoc);
+    const { node, pos, start } = findNodeAtSelection(selection);
+    expect(node).toBe(expectedEnd);
+    expect(pos).toBe(16);
+    expect(start).toBe(17);
+  });
+
+  test('findNodeAtEndOfDoc', () => {
+    const { node } = findNodeAtEndOfDoc(pmDoc);
+    expect(node).toBe(expectedEnd);
+  });
+
+  test('findNodeAtStartOfDoc', () => {
+    const { node } = findNodeAtStartOfDoc(pmDoc);
+    expect(node).toBe(expectedStart);
   });
 });

--- a/@remirror/core/src/helpers/nodes.ts
+++ b/@remirror/core/src/helpers/nodes.ts
@@ -2,11 +2,11 @@ import {
   Attrs,
   MarkTypeParams,
   NodeTypeParams,
-  NullablePMNodeParams,
-  PMNodeParams,
+  OptionalProsemirrorNodeParams,
   PosParams,
   PredicateParams,
   ProsemirrorNode,
+  ProsemirrorNodeParams,
 } from '../types';
 import { bool } from './base';
 import { isProsemirrorNode } from './document';
@@ -27,9 +27,9 @@ type NodePredicateParams = PredicateParams<ProsemirrorNode>;
  *
  * @public
  */
-export interface NodeWithPosition extends PMNodeParams, PosParams {}
+export interface NodeWithPosition extends ProsemirrorNodeParams, PosParams {}
 
-interface FlattenParams extends NullablePMNodeParams, Partial<DescendParams> {}
+interface FlattenParams extends OptionalProsemirrorNodeParams, Partial<DescendParams> {}
 
 /**
  * Flattens descendants of a given `node`.
@@ -166,7 +166,7 @@ interface FindChildrenByMarkParams extends FlattenParams, MarkTypeParams {}
 export const findChildrenByMark = ({ node, type, descend }: FindChildrenByMarkParams) =>
   findChildren({ node, predicate: child => bool(type.isInSet(child.marks)), descend });
 
-interface ContainsParams extends PMNodeParams, NodeTypeParams {}
+interface ContainsParams extends ProsemirrorNodeParams, NodeTypeParams {}
 
 /**
  * Returns `true` if a given node contains nodes of a given `nodeType`

--- a/@remirror/core/src/helpers/utils.ts
+++ b/@remirror/core/src/helpers/utils.ts
@@ -7,11 +7,13 @@ import {
   NodeTypeParams,
   NodeTypesParams,
   PMNodeParams,
+  PosParams,
   PredicateParams,
   ProsemirrorNode,
   Selection,
   SelectionParams,
   Transaction,
+  TransactionParams,
 } from '../types';
 import { bool, isNumber } from './base';
 import { isNodeSelection, isSelection, isTextDOMNode } from './document';
@@ -43,6 +45,7 @@ export const cloneTransaction = (tr: Transaction): Transaction => {
   return Object.assign(Object.create(tr), tr).setTime(Date.now());
 };
 
+interface RemoveNodeAtPositionParams extends TransactionParams, PosParams {}
 /**
  * Returns a `delete` transaction that removes a node at a given position with the given `node`.
  * `position` should point at the position immediately before the node.
@@ -51,9 +54,14 @@ export const cloneTransaction = (tr: Transaction): Transaction => {
  *
  * @public
  */
-export const removeNodeAtPos = (position: number) => (tr: Transaction) => {
-  const node = tr.doc.nodeAt(position);
-  return cloneTransaction(tr.delete(position, position + node!.nodeSize));
+export const removeNodeAtPosition = ({ pos, tr }: RemoveNodeAtPositionParams) => {
+  const node = tr.doc.nodeAt(pos);
+
+  if (!node) {
+    return tr;
+  }
+
+  return cloneTransaction(tr.delete(pos, pos + node.nodeSize));
 };
 
 /**
@@ -103,9 +111,9 @@ export const findElementAtPosition = (position: number, view: EditorView): HTMLE
  * @public
  */
 export const removeNodeBefore = (tr: Transaction): Transaction => {
-  const position = findPositionOfNodeBefore(tr.selection);
-  if (isNumber(position)) {
-    return removeNodeAtPos(position)(tr);
+  const pos = findPositionOfNodeBefore(tr.selection);
+  if (isNumber(pos)) {
+    return removeNodeAtPosition({ pos, tr });
   }
   return tr;
 };

--- a/@remirror/core/src/nodes/__tests__/paragraph.spec.ts
+++ b/@remirror/core/src/nodes/__tests__/paragraph.spec.ts
@@ -1,0 +1,48 @@
+import { ExtensionMap } from '@test-fixtures/schema-helpers';
+import { renderEditor } from 'jest-remirror';
+import { ParagraphExtension, ParagraphExtensionOptions } from '../paragraph';
+
+const { heading } = ExtensionMap.nodes;
+const create = (params: ParagraphExtensionOptions = { ensureTrailingParagraph: true }) =>
+  renderEditor({
+    plainNodes: [new ParagraphExtension({ ...params }), heading],
+  });
+
+describe('plugin', () => {
+  let {
+    add,
+    nodes: { doc, p, heading: h },
+  } = create();
+
+  beforeEach(() => {
+    ({
+      add,
+      nodes: { doc, p, heading: h },
+    } = create());
+  });
+
+  it('adds a new paragraph when needed', () => {
+    const { state } = add(doc(h('Yo')));
+    expect(state.doc).toEqualRemirrorDocument(doc(h('Yo'), p()));
+  });
+
+  it('does not add multiple paragraphs', () => {
+    const { state } = add(doc(p('Yo')));
+    expect(state.doc).toEqualRemirrorDocument(doc(p('Yo')));
+  });
+
+  it('dynamically appends paragraphs', () => {
+    const { state } = add(doc(p('Yo'), p('<cursor>'))).insertText('# Greatness');
+    expect(state.doc).toEqualRemirrorDocument(doc(p('Yo'), h('Greatness'), p()));
+  });
+
+  it('does nothing when `ensureTrailingParagraph` is false', () => {
+    ({
+      add,
+      nodes: { doc, p, heading: h },
+    } = create({ ensureTrailingParagraph: false }));
+
+    const { state } = add(doc(p('Yo'), p('<cursor>'))).insertText('# Greatness');
+    expect(state.doc).toEqualRemirrorDocument(doc(p('Yo'), h('Greatness')));
+  });
+});

--- a/@remirror/core/src/nodes/paragraph.ts
+++ b/@remirror/core/src/nodes/paragraph.ts
@@ -1,10 +1,37 @@
 import { setBlockType } from 'prosemirror-commands';
+import { Plugin } from 'prosemirror-state';
+import { ExtensionParams } from '../extension';
+import { findNodeAtEndOfDoc, FindParentNodeResult, getPluginState, nodeEqualsType } from '../helpers';
 import { NodeExtension } from '../node-extension';
-import { CommandNodeTypeParams, NodeExtensionOptions, NodeExtensionSpec } from '../types';
+import {
+  CommandNodeTypeParams,
+  NodeExtensionOptions,
+  NodeExtensionSpec,
+  NodeTypeParams,
+  SchemaNodeTypeParams,
+} from '../types';
 
-export class ParagraphExtension extends NodeExtension<NodeExtensionOptions, 'createParagraph', {}> {
+export interface ParagraphExtensionOptions extends NodeExtensionOptions {
+  /**
+   * Ensure that there's always a trailing paragraph at the end of the document.
+   *
+   * Why? In some scenarios it is difficult to place a cursor after the last element.
+   * This ensures there's always space to select the position afterward.
+   *
+   * @default false
+   */
+  ensureTrailingParagraph?: boolean;
+}
+
+export class ParagraphExtension extends NodeExtension<ParagraphExtensionOptions, 'createParagraph', {}> {
   get name() {
     return 'paragraph' as const;
+  }
+
+  get defaultOptions() {
+    return {
+      ensureTrailingParagraph: false,
+    };
   }
 
   get schema(): NodeExtensionSpec {
@@ -28,4 +55,58 @@ export class ParagraphExtension extends NodeExtension<NodeExtensionOptions, 'cre
       },
     };
   }
+
+  public plugin({ type }: SchemaNodeTypeParams): Plugin {
+    return createParagraphPlugin({ extension: this, type });
+  }
 }
+
+/**
+ * False when there is already a paragraph at the end of the document.
+ *
+ * The result of the find node when the node needs to be replaced.
+ */
+type ParagraphExtensionPluginState = false | FindParentNodeResult;
+
+interface CreateParagraphPluginParams extends NodeTypeParams, ExtensionParams {}
+
+/**
+ * Create the paragraph plugin which can check the end of the document and insert a new node if the option
+ * `ensureTrailingParagraph` is set to true.
+ */
+const createParagraphPlugin = ({ extension, type }: CreateParagraphPluginParams) => {
+  const { options, pluginKey } = extension;
+  const { ensureTrailingParagraph } = options;
+
+  return new Plugin<ParagraphExtensionPluginState>({
+    key: extension.pluginKey,
+    view() {
+      return {
+        update: view => {
+          const insertParagraphAtEnd = getPluginState<ParagraphExtensionPluginState>(pluginKey, view.state);
+
+          if (!insertParagraphAtEnd || !ensureTrailingParagraph) {
+            return;
+          }
+
+          const { pos, node } = insertParagraphAtEnd;
+          view.dispatch(view.state.tr.insert(pos + node.nodeSize, type.create()));
+        },
+      };
+    },
+    state: {
+      init: (_, state) => {
+        const result = findNodeAtEndOfDoc(state.tr.doc);
+        return nodeEqualsType({ node: result.node, types: type }) ? false : result;
+      },
+      apply: (tr, state) => {
+        if (!tr.docChanged) {
+          return state;
+        }
+
+        const result = findNodeAtEndOfDoc(tr.doc);
+        return nodeEqualsType({ node: result.node, types: type }) ? false : result;
+      },
+    },
+  });
+};

--- a/@remirror/core/src/types/builders.ts
+++ b/@remirror/core/src/types/builders.ts
@@ -123,14 +123,22 @@ export interface MarkTypeParams {
   type: MarkType;
 }
 
-export interface PMNodeParams {
+export interface ProsemirrorNodeParams {
   /**
    * The prosemirror node
    */
   node: ProsemirrorNode;
 }
 
-export interface NullablePMNodeParams {
+export interface DocParams {
+  /**
+   * The parent doc node of the editor which contains all the other nodes.
+   * This is also a ProsemirrorNode
+   */
+  doc: ProsemirrorNode;
+}
+
+export interface OptionalProsemirrorNodeParams {
   /**
    * The nullable prosemirror node which may or may not exist.
    */

--- a/@remirror/core/src/types/index.ts
+++ b/@remirror/core/src/types/index.ts
@@ -11,7 +11,7 @@ import {
   ProsemirrorNode,
   Value,
 } from './base';
-import { AttrsParams, EditorViewParams, PMNodeParams, SchemaParams } from './builders';
+import { AttrsParams, EditorViewParams, ProsemirrorNodeParams, SchemaParams } from './builders';
 
 /**
  * Used to apply the Prosemirror transaction to the current EditorState.
@@ -274,7 +274,7 @@ export interface GetAttrsParams {
 export type SSRComponentProps<
   GAttrs extends Attrs = any,
   GOptions extends BaseExtensionOptions = any
-> = GAttrs & PMNodeParams & { options: Required<GOptions> };
+> = GAttrs & ProsemirrorNodeParams & { options: Required<GOptions> };
 
 export * from './aliases';
 export * from './base';

--- a/@remirror/editor-wysiwyg/src/components/editor.tsx
+++ b/@remirror/editor-wysiwyg/src/components/editor.tsx
@@ -27,7 +27,7 @@ import { WysiwygEditorProps } from '../types';
 import { BubbleMenu, BubbleMenuProps, MenuBar } from './menu';
 import { EditorWrapper, InnerEditorWrapper } from './styled';
 
-import { deepMerge } from '@remirror/core';
+import { deepMerge, ParagraphExtension } from '@remirror/core';
 import bash from 'refractor/lang/bash';
 import markdown from 'refractor/lang/markdown';
 import tsx from 'refractor/lang/tsx';
@@ -97,6 +97,7 @@ export class WysiwygEditor extends PureComponent<WysiwygEditorProps> {
     return (
       <ThemeProvider theme={this.editorTheme}>
         <RemirrorManager placeholder={placeholder}>
+          <RemirrorExtension Constructor={ParagraphExtension} ensureTrailingParagraph={true} />
           <RemirrorExtension Constructor={BoldExtension} />
           <RemirrorExtension Constructor={UnderlineExtension} />
           <RemirrorExtension Constructor={ItalicExtension} />

--- a/@remirror/extension-code-block/src/__tests__/code-block.spec.ts
+++ b/@remirror/extension-code-block/src/__tests__/code-block.spec.ts
@@ -113,6 +113,32 @@ describe('plugin', () => {
     expect(newHtml).toMatchSnapshot();
   });
 
+  describe('Backspace', () => {
+    it('can be deleted', () => {
+      const { state } = add(doc(tsBlock('<cursor>'))).press('Backspace');
+      expect(state.doc).toEqualRemirrorDocument(doc(p()));
+    });
+
+    it('is still deleted when all that remains is whitespace', () => {
+      const { state } = add(doc(tsBlock('<cursor>          '))).press('Backspace');
+      expect(state.doc).toEqualRemirrorDocument(doc(p()));
+    });
+
+    it('steps into the previous node when content', () => {
+      const { state } = add(doc(p(), tsBlock('<cursor>content')))
+        .press('Backspace')
+        .insertText('abc');
+      expect(state.doc).toEqualRemirrorDocument(doc(p('abc'), tsBlock('content')));
+    });
+
+    it('creates a paragraph node when content', () => {
+      const { state } = add(doc(tsBlock('<cursor>content')))
+        .press('Backspace')
+        .insertText('abc');
+      expect(state.doc).toEqualRemirrorDocument(doc(p('abc'), tsBlock('content')));
+    });
+  });
+
   describe('Space', () => {
     it('responds to space input rule', () => {
       const { state } = add(doc(p('<cursor>'))).insertText('```typescript abc');

--- a/@remirror/extension-code-block/src/code-block-plugin.ts
+++ b/@remirror/extension-code-block/src/code-block-plugin.ts
@@ -193,6 +193,7 @@ export default function createCodeBlockPlugin({ extension, type }: CreateCodeBlo
     pluginState.setDeleted(true);
     return false;
   };
+
   return new Plugin<CodeBlockState>({
     key: extension.pluginKey,
     state: {

--- a/@remirror/extension-code-block/src/code-block-plugin.ts
+++ b/@remirror/extension-code-block/src/code-block-plugin.ts
@@ -6,7 +6,7 @@ import {
   NodeExtension,
   NodeType,
   NodeWithPosition,
-  PMNodeParams,
+  ProsemirrorNodeParams,
   SchemaNodeTypeParams,
   Transaction,
   TransactionParams,
@@ -164,7 +164,7 @@ export class CodeBlockState {
 }
 
 interface ApplyParams extends TransactionParams, CompareStateParams {}
-interface RefreshDecorationSetParams extends PMNodeParams {
+interface RefreshDecorationSetParams extends ProsemirrorNodeParams {
   /**
    * The positioned nodes
    */

--- a/@remirror/extension-code-block/src/code-block-types.ts
+++ b/@remirror/extension-code-block/src/code-block-types.ts
@@ -68,8 +68,20 @@ export interface CodeBlockExtensionOptions extends NodeExtensionOptions {
    * @default `Alt-Shift-F` (Mac) `Shift-Ctrl-F` (PC)
    */
   keyboardShortcut?: string;
+
+  /**
+   * The name of the node that the code block should toggle back and forth from.
+   *
+   * @default 'paragraph'
+   */
+  toggleType?: string;
 }
 
+/**
+ * A function which takes code and formats the code.
+ *
+ * TODO - possibly allow error management if failure is because of invalid syntax
+ */
 export type CodeBlockFormatter = (params: FormatterParams) => FormattedContent | undefined;
 
 export interface FormatterParams {

--- a/@remirror/extension-code-block/src/code-block-utils.ts
+++ b/@remirror/extension-code-block/src/code-block-utils.ts
@@ -185,17 +185,6 @@ export const updateNodeAttrs = (type: NodeType) => (attrs?: Attrs): CommandFunct
   return true;
 };
 
-// interface FormatCodeBlockTransactionParams extends FormatCodeBlockFactoryParams, RangeParams, TransactionParams {}
-// /**
-//  * Updates the provided Transaction with a transformed codeBlock
-//  *
-//  * The transaction is mutated if there is a change and the function returns true to indicate
-//  * that it should be dispatched and false to suggest otherwise.
-//  */
-// const formatCodeBlockTransaction = ({}: FormatCodeBlockTransactionParams): boolean => {
-
-// }
-
 interface FormatCodeBlockFactoryParams
   extends NodeTypeParams,
     Required<Pick<CodeBlockExtensionOptions, 'formatter' | 'supportedLanguages' | 'defaultLanguage'>> {}

--- a/@remirror/extension-code-block/src/code-block-utils.ts
+++ b/@remirror/extension-code-block/src/code-block-utils.ts
@@ -12,8 +12,8 @@ import {
   NodeType,
   NodeTypeParams,
   NodeWithPosition,
-  PMNodeParams,
   PosParams,
+  ProsemirrorNodeParams,
   TextParams,
   uniqueArray,
 } from '@remirror/core';
@@ -134,7 +134,7 @@ export const posWithinRange = ({ from, to, pos }: PosWithinRangeParams) => from 
 export const lengthHasChanged = <GType>(prev: ArrayLike<GType>, next: ArrayLike<GType>) =>
   next.length !== prev.length;
 
-export interface NodeInformation extends NodeTypeParams, FromToParams, PMNodeParams, PosParams {}
+export interface NodeInformation extends NodeTypeParams, FromToParams, ProsemirrorNodeParams, PosParams {}
 
 /**
  * Retrieves helpful node information from the current state.

--- a/@remirror/react/src/components/__tests__/remirror-manager.spec.tsx
+++ b/@remirror/react/src/components/__tests__/remirror-manager.spec.tsx
@@ -1,5 +1,5 @@
-import { ExtensionManager } from '@remirror/core';
-import { PlaceholderExtension } from '@remirror/core-extensions';
+import { ExtensionManager, ParagraphExtension } from '@remirror/core';
+import { baseExtensions, PlaceholderExtension } from '@remirror/core-extensions';
 import { TestExtension } from '@test-fixtures/schema-helpers';
 import { render, RenderResult } from '@testing-library/react';
 import { EditorView } from 'prosemirror-view';
@@ -121,6 +121,24 @@ test('it supports <RemirrorExtension /> in child fragments', () => {
         emptyNodeClass='empty'
         placeholder='Type here...'
       />
+    </RemirrorManager>,
+  );
+});
+
+test('it supports overriding base extensions', () => {
+  const originalParagraph = baseExtensions.find(({ extension: { name } }) => name === 'paragraph');
+
+  const Component: FC = () => {
+    const manager = useRemirrorManager();
+    expect(manager.extensions).not.toContain([originalParagraph]);
+    expect(manager.extensions.find(({ options }) => options.ensureTrailingParagraph === true)).toBeTruthy();
+    return null;
+  };
+
+  render(
+    <RemirrorManager>
+      <Component />
+      <RemirrorExtension Constructor={ParagraphExtension} ensureTrailingParagraph={true} />
     </RemirrorManager>,
   );
 });

--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@ and this project will adhere to [Semantic Versioning](https://semver.org/spec/v2
 - `@remirror/react-utils`, `@remirror/react`: Add `suppressHydrationWarning` prop to `Remirror` component. Set to true to ignore the hydration warning for a mismatch between the server and client content.
 - `@remirror/core`: Add new `extensionData` method to the `ExtensionManager` which allows extension to provide data on every transaction which will be available for consumption in the renderProp, React Context hooks and HOC's.
 - `@remirror/core`: Add `getActions` to the params of all extension manager methods. This will throw an error if called before initialization.
+- `@remirror/core`: Allow extensions to override `baseExtension` in the `RemirrorManager` component.
 - `@remirror/core`: Add `ensureTrailingParagraph` as a configuration option for the paragraph node. In some scenarios it is difficult to place a cursor after the last element. This ensures there's always space to select the position afterward and fixes a whole range of issues. It defaults to false otherwise it breaks a lot of tests.
 - `jest-prosemirror`: Enable editorViewOptions for the `createEditor` method. For example, now it is possible to intercept transactions with the `dispatchTransaction` hook.
 - `@remirror/renderer-react`: Pass extension options through to SSR components as a prop.

--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@ and this project will adhere to [Semantic Versioning](https://semver.org/spec/v2
 - `@remirror/react-utils`, `@remirror/react`: Add `suppressHydrationWarning` prop to `Remirror` component. Set to true to ignore the hydration warning for a mismatch between the server and client content.
 - `@remirror/core`: Add new `extensionData` method to the `ExtensionManager` which allows extension to provide data on every transaction which will be available for consumption in the renderProp, React Context hooks and HOC's.
 - `@remirror/core`: Add `getActions` to the params of all extension manager methods. This will throw an error if called before initialization.
+- `@remirror/core`: Add `ensureTrailingParagraph` as a configuration option for the paragraph node. In some scenarios it is difficult to place a cursor after the last element. This ensures there's always space to select the position afterward and fixes a whole range of issues. It defaults to false otherwise it breaks a lot of tests.
 - `jest-prosemirror`: Enable editorViewOptions for the `createEditor` method. For example, now it is possible to intercept transactions with the `dispatchTransaction` hook.
 - `@remirror/renderer-react`: Pass extension options through to SSR components as a prop.
 

--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,7 @@ and this project will adhere to [Semantic Versioning](https://semver.org/spec/v2
 
 - 🚀 `@remirror/extension-collaboration`: Collaboration library added based on the brilliant example available in [tiptap](https://github.com/scrumpy/tiptap).
 - 🚀 `@remirror/extension-mention`: Mentions can now be picked up from pasting data.
-- 🚀 `@remirror/extension-code-block`: Add commands `toggleCodeBlock`, `createCodeBlock`, `updateCodeBlock` and `formatCodeBlock` also add keymap support for formatting and other features.
+- 🚀 `@remirror/extension-code-block`: Add commands `toggleCodeBlock`, `createCodeBlock`, `updateCodeBlock` and `formatCodeBlock`, add keymap support for formatting, add backspace support for better navigation and other features.
 - `@remirror/core`: Add `CommandNodeTypeParams`, `CommandMarkTypeParams`, `CommandTypeParams` which is now passed to the `commands` method for extensions.
 - `@remirror/react-utils`, `@remirror/react`: Add `suppressHydrationWarning` prop to `Remirror` component. Set to true to ignore the hydration warning for a mismatch between the server and client content.
 - `@remirror/core`: Add new `extensionData` method to the `ExtensionManager` which allows extension to provide data on every transaction which will be available for consumption in the renderProp, React Context hooks and HOC's.

--- a/packages/jest-remirror/src/render-editor.tsx
+++ b/packages/jest-remirror/src/render-editor.tsx
@@ -73,7 +73,8 @@ export const renderEditor = <
   props: Partial<Omit<RemirrorProps, 'manager'>> = {},
 ): GReturn => {
   const extensions = [
-    ...nodeExtensions,
+    // Allow testing the paragraph, text and doc extensions by filtering them out when they've been passed in
+    ...nodeExtensions.filter(({ name }) => !plainNodes.some(ext => ext.name === name)),
     ...others,
     ...plainMarks,
     ...plainNodes,

--- a/support/fixtures/schema-helpers.ts
+++ b/support/fixtures/schema-helpers.ts
@@ -16,6 +16,7 @@ import {
   UnderlineExtension,
   BlockquoteExtension,
   HistoryExtension,
+  HeadingExtension,
 } from '@remirror/core-extensions';
 import minDocument from 'min-document';
 
@@ -38,6 +39,21 @@ export const extensions = [
   { extension: new UnderlineExtension(), priority: 3 },
   { extension: new BlockquoteExtension(), priority: 3 },
 ];
+
+/**
+ * Useful for testing
+ */
+export const ExtensionMap = {
+  nodes: {
+    blockquote: new BlockquoteExtension(),
+    heading: new HeadingExtension(),
+  },
+  marks: {
+    bold: new BoldExtension(),
+    italic: new ItalicExtension(),
+    underline: new UnderlineExtension(),
+  },
+};
 
 /**
  * @deprecated Causes issues when multiple tests use this. Prefer {@link createTestManager}


### PR DESCRIPTION
## Description

- `@remirror/core`: Allow extensions to override `baseExtension` in the `RemirrorManager` component.

- `@remirror/core`: Add `ensureTrailingParagraph` as a configuration option for the paragraph node. In some scenarios it is difficult to place a cursor after the last element. This ensures there's always space to select the position afterward and fixes a whole range of issues. It defaults to false otherwise it breaks a lot of tests. Similar to https://github.com/scrumpy/tiptap/issues/143

- 🚀 `@remirror/extension-code-block`: Add backspace support for more easily deleting an empty code block.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**CONTRIBUTING**](https://github.com/ifiokjr/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `yarn fix` runs successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `yarn test` .

## Screenshots

#### `ensureTrailingParagraph`

![2019-07-20 20 20 43](https://user-images.githubusercontent.com/1160934/61583176-5be29f00-ab2c-11e9-91fe-20683dcb9b16.gif)

#### `codeBlock` Backspace

![2019-07-20 19 44 05](https://user-images.githubusercontent.com/1160934/61583185-83396c00-ab2c-11e9-8170-914d3db032d3.gif)
