### PR TITLE
feat: add the ability to parse the dom for extra attributes

### DIFF
--- a/@remirror/core-extensions/src/marks/link.ts
+++ b/@remirror/core-extensions/src/marks/link.ts
@@ -46,6 +46,7 @@ export class LinkExtension extends MarkExtension<LinkExtensionOptions, LinkExten
   get schema(): MarkExtensionSpec {
     return {
       attrs: {
+        ...this.extraAttrs(null),
         href: {
           default: null,
         },
@@ -56,6 +57,7 @@ export class LinkExtension extends MarkExtension<LinkExtensionOptions, LinkExten
           tag: 'a[href]',
           getAttrs: node => ({
             href: Cast<Element>(node).getAttribute('href'),
+            ...this.getExtraAttrs(Cast<Element>(node)),
           }),
         },
       ],

--- a/@remirror/core-extensions/src/nodes/__tests__/heading.spec.ts
+++ b/@remirror/core-extensions/src/nodes/__tests__/heading.spec.ts
@@ -1,3 +1,5 @@
+/* tslint:disable: no-shadowed-variable */
+
 import { fromHTML, toHTML } from '@remirror/core';
 import { createBaseTestManager } from '@test-fixtures/schema-helpers';
 import { pmBuild } from 'jest-prosemirror';
@@ -26,6 +28,36 @@ describe('schema', () => {
     const node = fromHTML({ content: '<h2>Hello</h2>', schema });
     const expected = doc(h2('Hello'));
     expect(node).toEqualPMNode(expected);
+  });
+
+  describe('extraAttrs', () => {
+    const { schema } = createBaseTestManager([
+      {
+        extension: new HeadingExtension({ extraAttrs: ['title', ['custom', 'failure', 'data-custom']] }),
+        priority: 1,
+      },
+    ]);
+
+    it('sets the extra attributes', () => {
+      expect(schema.nodes.heading.spec.attrs).toEqual({
+        level: { default: 1 },
+        title: { default: null },
+        custom: { default: 'failure' },
+      });
+    });
+
+    it('does not override the built in attributes', () => {
+      const { schema } = createBaseTestManager([
+        {
+          extension: new HeadingExtension({ extraAttrs: [['level', 'should not appear']] }),
+          priority: 1,
+        },
+      ]);
+
+      expect(schema.nodes.heading.spec.attrs).toEqual({
+        level: { default: 1 },
+      });
+    });
   });
 });
 

--- a/@remirror/core-extensions/src/nodes/heading.ts
+++ b/@remirror/core-extensions/src/nodes/heading.ts
@@ -17,25 +17,27 @@ export interface HeadingExtensionOptions extends NodeExtensionOptions {
   defaultLevel?: number;
 }
 
+export const defaultHeadingExtensionOptions = {
+  levels: [1, 2, 3, 4, 5, 6],
+  defaultLevel: 1,
+};
+
 export class HeadingExtension extends NodeExtension<HeadingExtensionOptions, 'toggleHeading'> {
   get name() {
     return 'heading' as const;
   }
 
   get defaultOptions() {
-    return {
-      levels: [1, 2, 3, 4, 5, 6],
-      defaultLevel: 1,
-    };
+    return defaultHeadingExtensionOptions;
   }
 
   get schema(): NodeExtensionSpec {
     return {
       attrs: {
+        ...this.extraAttrs(null),
         level: {
           default: this.options.defaultLevel,
         },
-        ...this.extraAttrs(),
       },
       content: 'inline*',
       group: 'block',

--- a/@remirror/core/src/__tests__/node-extension.spec.ts
+++ b/@remirror/core/src/__tests__/node-extension.spec.ts
@@ -1,0 +1,80 @@
+import { createBaseTestManager } from '@test-fixtures/schema-helpers';
+import { pmBuild } from 'jest-prosemirror';
+import { NodeExtension } from '../';
+import { fromHTML } from '../helpers';
+import { NodeExtensionSpec } from '../types';
+
+class CustomExtension extends NodeExtension {
+  get name() {
+    return 'custom' as const;
+  }
+
+  get schema(): NodeExtensionSpec {
+    return {
+      content: 'inline*',
+      group: 'block',
+      attrs: this.extraAttrs(),
+      draggable: false,
+      parseDOM: [
+        {
+          tag: 'p',
+          getAttrs: node => this.getExtraAttrs(node as Element),
+        },
+      ],
+      toDOM: () => ['p', 0],
+    };
+  }
+}
+
+describe('extraAttrs', () => {
+  const run = 'true';
+  const title = 'awesome';
+
+  const { schema } = createBaseTestManager([
+    {
+      extension: new CustomExtension({
+        extraAttrs: [
+          'title',
+          ['run', 'failure', 'data-run'],
+          {
+            default: 'yo',
+            getAttrs: domNode => (domNode as Element).getAttribute('simple'),
+            name: 'crazy',
+          },
+        ],
+      }),
+      priority: 1,
+    },
+  ]);
+  const { doc, custom, other } = pmBuild(schema, {
+    custom: { nodeType: 'custom', run, title, crazy: 'yo' },
+    other: { nodeType: 'custom', run, title, crazy: 'believe me' },
+  });
+
+  it('creates attrs with the correct shape', () => {
+    expect(schema.nodes.custom.spec.attrs).toEqual({
+      title: { default: '' },
+      run: { default: 'failure' },
+      crazy: { default: 'yo' },
+    });
+  });
+
+  it('parses the dom for extra attributes', () => {
+    const node = fromHTML({
+      content: `<p title="${title}" data-run="${run}">hello</p>`,
+      schema,
+    });
+
+    const expected = doc(custom('hello'));
+    expect(node).toEqualPMNode(expected);
+  });
+
+  it('support parsing with getAttrs method', () => {
+    const node = fromHTML({
+      content: `<p title="${title}" data-run="${run}" simple="believe me">hello</p>`,
+      schema,
+    });
+    const expected = doc(other('hello'));
+    expect(node).toEqualPMNode(expected);
+  });
+});

--- a/@remirror/core/src/nodes/__tests__/paragraph.spec.ts
+++ b/@remirror/core/src/nodes/__tests__/paragraph.spec.ts
@@ -1,6 +1,27 @@
-import { ExtensionMap } from '@test-fixtures/schema-helpers';
+import { createBaseTestManager, ExtensionMap } from '@test-fixtures/schema-helpers';
+import { pmBuild } from 'jest-prosemirror';
 import { renderEditor } from 'jest-remirror';
+import { fromHTML } from '../../helpers';
 import { ParagraphExtension, ParagraphExtensionOptions } from '../paragraph';
+
+describe('schema', () => {
+  let { schema } = createBaseTestManager([{ extension: new ParagraphExtension(), priority: 1 }]);
+  let { doc, p } = pmBuild(schema, {});
+
+  beforeEach(() => {
+    ({ schema } = createBaseTestManager([{ extension: new ParagraphExtension(), priority: 1 }]));
+    ({ doc, p } = pmBuild(schema, {}));
+  });
+
+  it('it can parse content', () => {
+    const node = fromHTML({
+      content: `<p>hello</p>`,
+      schema,
+    });
+    const expected = doc(p('hello'));
+    expect(node).toEqualPMNode(expected);
+  });
+});
 
 const { heading } = ExtensionMap.nodes;
 const create = (params: ParagraphExtensionOptions = { ensureTrailingParagraph: true }) =>

--- a/@remirror/core/src/nodes/paragraph.ts
+++ b/@remirror/core/src/nodes/paragraph.ts
@@ -38,10 +38,12 @@ export class ParagraphExtension extends NodeExtension<ParagraphExtensionOptions,
     return {
       content: 'inline*',
       group: 'block',
+      attrs: this.extraAttrs(),
       draggable: false,
       parseDOM: [
         {
           tag: 'p',
+          getAttrs: node => this.getExtraAttrs(node as Element),
         },
       ],
       toDOM: () => ['p', 0],

--- a/@remirror/core/src/types/base.ts
+++ b/@remirror/core/src/types/base.ts
@@ -174,10 +174,35 @@ export type Attrs<GExtra extends {} = {}> = Record<string, unknown> & GExtra;
 
 export type AttrsWithClass = Attrs & { class?: string };
 
+export interface ExtraAttrsObject {
+  /**
+   * The name of the attribute
+   */
+  name: string;
+
+  /**
+   * The default value for the attr, if left undefined then this becomes a required.
+   * and must be provided whenever a node or mark of a type that has them is
+   * created.
+   */
+  default?: string | null;
+
+  /**
+   * A function used to extract the attribute from the dom.
+   */
+  getAttrs?: (domNode: Node) => unknown;
+}
+
+/**
+ * The first value is the name of the attribute the second value is the default and the third
+ * is the optional parse name from the dom via `node.getAttribute()`.
+ */
+export type ExtraAttrsTuple = [string, string, string?];
+
 /**
  * Data representation tuple used for injecting extra attributes into an extension.
  */
-export type ExtraAttrs = Array<string | [string, string]>;
+export type ExtraAttrs = string | ExtraAttrsTuple | ExtraAttrsObject;
 
 /**
  * Defines the options that every extension can accept at instantiation.
@@ -195,9 +220,18 @@ export interface BaseExtensionOptions {
    * Inject additional attributes into the defined mark / node schema.
    * This can only be used for `NodeExtensions` and `MarkExtensions`.
    *
+   * @remarks
+   *
+   * Sometimes you need to add additional attributes to a node or mark. This property
+   * enables this without needing to create a new extension.
+   *
+   * - `extraAttrs: ['title']` Create an attribute with name `title`.When parsing the dom it will look for the attribute `title`
+   * - `extraAttrs: [['custom', 'false', 'data-custom'],'title']` - Creates an attribute with name `custom` and default value `false`.
+   * When parsing the dom it will look for the attribute `data-custom`
+   *
    * @default []
    */
-  extraAttrs?: ExtraAttrs;
+  extraAttrs?: ExtraAttrs[];
 
   /**
    * a configuration object which allows for excluding certain functionality from an extension.

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,8 @@ and this project will adhere to [Semantic Versioning](https://semver.org/spec/v2
 ### Changes
 
 - `@remirror/core`: Update `extraAttrs` configuration to enable parsing the dom.
+- `@remirror/core-extensions`: Add `extraAttrs` to the following extensions:
+  `LinkExtension`, `ParagraphExtension`, `HeadingExtension`.
 
 ## [0.4.1] - 2019-07-22
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,14 @@ and this project will adhere to [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Added
+
+- `@remirror/core`: Add `getExtraAttrs` method to the extension which can be used in the `(Mark/Node)Extension`.
+
+### Changes
+
+- `@remirror/core`: Update `extraAttrs` configuration to enable parsing the dom.
+
 ## [0.4.1] - 2019-07-22
 
 ### Changes


### PR DESCRIPTION
## Description

- `@remirror/core`: Add `getExtraAttrs` method to the extension which can be used in the `(Mark/Node)Extension`.
- `@remirror/core`: Update `extraAttrs` configuration to enable parsing the dom.
- `@remirror/core-extensions`: Add `extraAttrs` to the following extensions:
  `LinkExtension`, `ParagraphExtension`, `HeadingExtension`.

Closes #113

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**CONTRIBUTING**](https://github.com/ifiokjr/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `yarn fix` runs successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `yarn test` .
