### PR TITLE
fix: unstable extension order after sort

### DIFF
--- a/@remirror/core/src/__tests__/extension-manager.helpers.spec.ts
+++ b/@remirror/core/src/__tests__/extension-manager.helpers.spec.ts
@@ -6,8 +6,13 @@ describe('transformExtensionMap', () => {
   it('maps the extensions', () => {
     const doc = new DocExtension();
     const p = new TestExtension();
-    const extensions = [{ extension: doc, priority: 2 }, { extension: p, priority: 2 }];
-    expect(transformExtensionMap(extensions)).toEqual([doc, p]);
+    const text = new TextExtension();
+    const extensions = [
+      { extension: doc, priority: 2 },
+      { extension: p, priority: 2 },
+      { extension: text, priority: 2 },
+    ];
+    expect(transformExtensionMap(extensions)).toEqual([doc, p, text]);
   });
 
   it('sorts the extensions by priority', () => {

--- a/@remirror/core/src/extension-manager.helpers.ts
+++ b/@remirror/core/src/extension-manager.helpers.ts
@@ -6,7 +6,7 @@ import {
   isExtension,
   PrioritizedExtension,
 } from './extension';
-import { bool, Cast, isFunction } from './helpers/base';
+import { bool, Cast, isFunction, sort } from './helpers/base';
 import { isMarkExtension } from './mark-extension';
 import { isNodeExtension } from './node-extension';
 import {
@@ -273,7 +273,7 @@ export const extensionPropertyMapper = <
  * Converts an extension to its mapped value
  */
 function convertToExtensionMapValue(extension: FlexibleExtension): PrioritizedExtension {
-  return isExtension(extension) ? { priority: DEFAULT_EXTENSION_PRIORITY, extension } : extension;
+  return isExtension(extension) ? { priority: DEFAULT_EXTENSION_PRIORITY, extension } : { ...extension };
 }
 
 /**
@@ -286,10 +286,9 @@ function convertToExtensionMapValue(extension: FlexibleExtension): PrioritizedEx
  * @returns the list of extension instances sorted by priority
  */
 export const transformExtensionMap = (values: FlexibleExtension[]) =>
-  values
-    .map(convertToExtensionMapValue)
-    .sort((a, b) => a.priority - b.priority)
-    .map(({ extension }) => extension);
+  sort(values.map(convertToExtensionMapValue), (a, b) => a.priority - b.priority).map(
+    ({ extension }) => extension,
+  );
 
 /**
  * Takes in an object and removes all function values.

--- a/@remirror/core/src/helpers/__tests__/base.spec.ts
+++ b/@remirror/core/src/helpers/__tests__/base.spec.ts
@@ -26,6 +26,7 @@ import {
   isSymbol,
   isUndefined,
   randomInt,
+  sort,
   startCase,
   take,
   trim,
@@ -269,4 +270,20 @@ test('uniqueArray', () => {
 
   const dup = ['a', 'a', 'a', 'a', 'b'];
   expect(uniqueArray(dup)).toEqual(['a', 'b']);
+});
+
+test('sort', () => {
+  const arr = [...Array(100), 11, 9, 12].map((value, index) => ({ value: value || 10, index }));
+  // expect(arr.sort((a, b) => a.value - b.value)).toEqual([
+  //   { value: 9, index: 101 },
+  //   ...take(arr, 100),
+  //   { value: 11, index: 100 },
+  //   { value: 12, index: 102 },
+  // ]);
+  expect(sort(arr, (a, b) => a.value - b.value)).toEqual([
+    { value: 9, index: 101 },
+    ...take(arr, 100),
+    { value: 11, index: 100 },
+    { value: 12, index: 102 },
+  ]);
 });

--- a/@remirror/core/src/helpers/base.ts
+++ b/@remirror/core/src/helpers/base.ts
@@ -683,6 +683,28 @@ export const clamp = ({ min, max, value }: ClampParams): number =>
   value < min ? min : value > max ? max : value;
 
 /**
- * Get the last element of the array
+ * Get the last element of the array.
  */
 export const last = <GType>(array: GType[]) => array[array.length - 1];
+
+/**
+ * Sorts an array while retaining the original order when the compare method
+ * identifies the items as equal.
+ *
+ * `Array.prototype.sort()` is unstable and so values that are the same
+ * will jump around in a non deterministic manner. Here I'm using the index
+ * as a fallback. If two elements have the same priority the element with
+ * the lower index is placed first hence retaining the original order.
+ *
+ * @param array - the array to sort
+ * @param compareFn - compare the two value arguments `a` and `b`
+ *                  - return 0 for equal
+ *                  - return number > 0 for a > b
+ *                  - return number < 0 for b > a
+ */
+export const sort = <GType>(array: GType[], compareFn: (a: GType, b: GType) => number) => {
+  return array
+    .map((value, index) => ({ value, index }))
+    .sort((a, b) => compareFn(a.value, b.value) || a.index - b.index)
+    .map(({ value }) => value);
+};


### PR DESCRIPTION
## Description

Closes #125 

Fixes a bug with using unstable `Array.prototyp.sort` by creating a new sort helper that ensures sorts are stable. 

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**CONTRIBUTING**](https://github.com/ifiokjr/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `yarn fix` runs successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `yarn test` .
