### PR TITLE
Fix contributing links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,4 +15,4 @@ about: Create a report to help us improve
 
 - [ ] I have read the [**contributing**][contributing] document.
 
-[contributing]: https://github.com/ifiokjr/remirror/blob/master/docs/pages/contributing.md
+[contributing]: https://github.com/ifiokjr/remirror/blob/canary/docs/pages/contributing.md

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -7,4 +7,4 @@ about: Describe this issue template's purpose here.
 
 - [ ] I have read the [**contributing**][contributing] document.
 
-[contributing]: https://github.com/ifiokjr/remirror/blob/master/docs/pages/contributing.md
+[contributing]: https://github.com/ifiokjr/remirror/blob/canary/docs/pages/contributing.md

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -15,4 +15,4 @@ about: Suggest an idea for this project
 
 - [ ] I have read the [**contributing**][contributing] document.
 
-[contributing]: https://github.com/ifiokjr/remirror/blob/master/docs/pages/contributing.md
+[contributing]: https://github.com/ifiokjr/remirror/blob/canary/docs/pages/contributing.md

--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ yarn stop:checks
 
 ### Contributing
 
-Please read [contributing.md](https://github.com/ifiokjr/remirror/blob/master/docs/pages/contributing.md) for details on our code of conduct, and the process for submitting pull requests.
+Please read [contributing.md](docs/pages/contributing.md) for details on our code of conduct, and the process for submitting pull requests.
 
 ### Versioning
 


### PR DESCRIPTION
## Description

The contributing link references `master` but that's out of date with `canary` (the link doesn't work). This PR fixes the link in the README to be relative (which should work on any branch) and fixes the links referenced in the issue templates.

## Checklist

- [x] I have read the **contributing** document.
- [x] My code follows the code style of this project and `yarn fix` runs successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `yarn test` .
