### PR TITLE
Fix E2E tests on Linux

### DIFF
--- a/e2e/wysiwyg.e2e.test.ts
+++ b/e2e/wysiwyg.e2e.test.ts
@@ -58,14 +58,14 @@ describe('Wysiwyg Showcase', () => {
     const formatted = `function concatAwesome(str: string) {\n  return 'Awesome ' + str;\n}\n`;
     it('supports formatting', async () => {
       await $editor.type('```ts ' + unformatted);
-      await pressKeyWithModifier(mod('ShiftAlt', 'f'));
+      await pressKeyWithModifier(mod('ShiftAlt', 'KeyF'));
       await expect(textContent('pre.language-ts > code')).resolves.toBe(formatted);
     });
 
     it('preserves position while formatting', async () => {
       await $editor.type('```ts ' + unformatted);
       await press({ key: 'ArrowLeft', count: 9 });
-      await pressKeyWithModifier(mod('ShiftAlt', 'f'));
+      await pressKeyWithModifier(mod('ShiftAlt', 'KeyF'));
       await $editor.type(' World');
       await expect(textContent('pre.language-ts > code')).resolves.toBe(
         `function concatAwesome(str: string) {\n  return 'Awesome World ' + str;\n}\n`,
@@ -81,7 +81,7 @@ describe('Wysiwyg Showcase', () => {
       await press({ key: 'ArrowRight', count: 7 });
       await page.keyboard.up('Shift');
 
-      await pressKeyWithModifier(mod('ShiftAlt', 'f'));
+      await pressKeyWithModifier(mod('ShiftAlt', 'KeyF'));
       await $editor.type('Oops');
 
       await expect(textContent('pre.language-ts > code')).resolves.toBe(


### PR DESCRIPTION
## Description

See #146 - three E2E tests were failing on linux; these changes make everything green.

Note [the puppeteer 'keyboard.press' docs](https://pptr.dev/#?product=Puppeteer&version=v1.19.0&show=api-keyboardpresskey-options) reference [the US keyboard layout](https://github.com/GoogleChrome/puppeteer/blob/master/lib/USKeyboardLayout.js) which is where `KeyF` originates. Though `f` is also defined in that file, for some reason it does not seem to work on linux :man_shrugging: 

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**][contributing] document.
- [x] My code follows the code style of this project and `yarn fix` runs successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `yarn test` .

[contributing]: https://github.com/ifiokjr/remirror/blob/master/docs/pages/contributing.md
