### PR TITLE
test: add HTML snapshot tests

### DIFF
--- a/e2e/helpers/index.ts
+++ b/e2e/helpers/index.ts
@@ -101,3 +101,15 @@ export const type = async ({ text, delay = 10 }: TypeParams) => page.keyboard.ty
 export * from './modifier-keys';
 
 export * from './images';
+
+interface HTMLObject {
+  _: 'HTML';
+  html: string;
+}
+
+function makeHtmlObject(htmlOrPromise: string | Promise<string>): Promise<HTMLObject> {
+  return Promise.resolve(htmlOrPromise).then(html => Promise.resolve({ _: 'HTML', html }));
+}
+
+export const $innerHTML = (selector: string) =>
+  makeHtmlObject(page.$eval(selector, element => element.innerHTML));

--- a/e2e/helpers/serializers/html-serializer.js
+++ b/e2e/helpers/serializers/html-serializer.js
@@ -1,0 +1,18 @@
+const prettier = require('prettier');
+const indentString = require('indent-string');
+
+module.exports = {
+  test: val => val._ === 'HTML',
+
+  serialize(val, config, _indentation, depth, _refs, _printer) {
+    const html = val.html;
+    const prettified = prettier.format(html, {
+      parser: 'html',
+      htmlWhitespaceSensitivity: 'css',
+    });
+
+    return indentString(prettified, depth + 1, {
+      indent: config.indent,
+    }).trim();
+  },
+};

--- a/e2e/jest.config.js
+++ b/e2e/jest.config.js
@@ -23,7 +23,6 @@ module.exports = {
     __SERVER__,
   },
   transform,
-  rootDir: baseDir('e2e'),
   testPathIgnorePatterns,
   testRegex: __SERVER__.regex,
   cacheDirectory,
@@ -34,4 +33,5 @@ module.exports = {
   setupFilesAfterEnv: ['expect-puppeteer', jestSupportDir('jest.framework.ts')],
   globalSetup: jestSupportDir('jest.puppeteer.setup.ts'),
   globalTeardown: jestSupportDir('jest.puppeteer.teardown.ts'),
+  snapshotSerializers: [`${__dirname}/helpers/serializers/html-serializer`],
 };

--- a/e2e/social.e2e.test.ts
+++ b/e2e/social.e2e.test.ts
@@ -1,7 +1,18 @@
 import { EDITOR_CLASS_SELECTOR } from '@remirror/core';
 import { getDocument, queries } from 'pptr-testing-library';
 import { ElementHandle } from 'puppeteer';
-import { innerHtml, outerHtml, press, sel, skipTestOnFirefox, textContent, type } from './helpers';
+import {
+  innerHtml,
+  outerHtml,
+  press,
+  sel,
+  skipTestOnFirefox,
+  textContent,
+  type,
+  $innerHTML,
+} from './helpers';
+
+const FIRST_PARAGRAPH_SELECTOR = EDITOR_CLASS_SELECTOR + ' > p:first-child';
 
 const { getByRole } = queries;
 const path = __SERVER__.urls.social.empty;
@@ -20,8 +31,8 @@ describe('Social Showcase', () => {
     it('should have a social editor', async () => {
       await $editor.focus();
       await $editor.type('This is text https://url.com');
-      await expect(innerHtml(EDITOR_CLASS_SELECTOR)).resolves.toInclude(
-        '<a href="https://url.com" role="presentation">https://url.com</a>',
+      await expect($innerHTML(FIRST_PARAGRAPH_SELECTOR)).resolves.toMatchInlineSnapshot(
+        `This is text <a href="https://url.com" role="presentation">https://url.com</a>`,
       );
     });
 

--- a/support/jest/jest.framework.ts
+++ b/support/jest/jest.framework.ts
@@ -4,7 +4,7 @@ import { configureToMatchImageSnapshot } from 'jest-image-snapshot';
 
 if (__E2E__) {
   jest.setTimeout(120000);
-  jest.retryTimes(2);
+  //jest.retryTimes(2);
 
   /* A failureThreshold of 1 will pass tests that have > 2 percent failing pixels */
   const customConfig = { threshold: 0.3 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6208,26 +6208,6 @@ bytes@3.1.0, bytes@^3.1.0:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
   integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
 
-cacache@^11.2.0:
-  version "11.3.3"
-  resolved "https://registry.yarnpkg.com/cacache/-/cacache-11.3.3.tgz#8bd29df8c6a718a6ebd2d010da4d7972ae3bbadc"
-  integrity sha512-p8WcneCytvzPxhDvYp31PD039vi77I12W+/KfR9S8AZbaiARFBCpsPJS+9uhWfeBfeAtW7o/4vt3MUqLkbY6nA==
-  dependencies:
-    bluebird "^3.5.5"
-    chownr "^1.1.1"
-    figgy-pudding "^3.5.1"
-    glob "^7.1.4"
-    graceful-fs "^4.1.15"
-    lru-cache "^5.1.1"
-    mississippi "^3.0.0"
-    mkdirp "^0.5.1"
-    move-concurrently "^1.0.1"
-    promise-inflight "^1.0.1"
-    rimraf "^2.6.3"
-    ssri "^6.0.1"
-    unique-filename "^1.1.1"
-    y18n "^4.0.0"
-
 cacache@^12.0.0, cacache@^12.0.2, cacache@^12.0.3:
   version "12.0.3"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-12.0.3.tgz#be99abba4e1bf5df461cd5a2c1071fc432573390"
@@ -7032,18 +7012,6 @@ compressible@~2.0.16:
   dependencies:
     mime-db ">= 1.40.0 < 2"
 
-compression-webpack-plugin@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/compression-webpack-plugin/-/compression-webpack-plugin-3.0.0.tgz#097d2e4d95c3a14cb5c8ed20899009ab5b9bbca0"
-  integrity sha512-ls+oKw4eRbvaSv/hj9NmctihhBcR26j76JxV0bLRLcWhrUBdQFgd06z/Kgg7exyQvtWWP484wZxs0gIUX3NO0Q==
-  dependencies:
-    cacache "^11.2.0"
-    find-cache-dir "^3.0.0"
-    neo-async "^2.5.0"
-    schema-utils "^1.0.0"
-    serialize-javascript "^1.4.0"
-    webpack-sources "^1.0.1"
-
 compression@1.7.4, compression@^1.7.4:
   version "1.7.4"
   resolved "https://registry.yarnpkg.com/compression/-/compression-1.7.4.tgz#95523eff170ca57c29a0ca41e6fe131f41e5bb8f"
@@ -7671,7 +7639,7 @@ css-loader@^1.0.0, css-loader@^1.0.1:
     postcss-value-parser "^3.3.0"
     source-list-map "^2.0.0"
 
-css-loader@^3.0.0, css-loader@^3.1.0, css-loader@^3.2.0:
+css-loader@^3.0.0, css-loader@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-3.2.0.tgz#bb570d89c194f763627fcf1f80059c6832d009b2"
   integrity sha512-QTF3Ud5H7DaZotgdcJjGMvyDj5F3Pn1j/sC6VBEOVp94cbwqyIBdcs/quzj4MC1BKQSrTpQznegH/5giYbhnCQ==
@@ -8349,6 +8317,11 @@ diff@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
+
+diff@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.1.tgz#0c667cb467ebbb5cea7f14f135cc2dba7780a8ff"
+  integrity sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -9407,16 +9380,6 @@ esrecurse@^4.1.0:
   dependencies:
     estraverse "^4.1.0"
 
-estimo@^1.1.3:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/estimo/-/estimo-1.1.6.tgz#44273e99de905848fe4a3ae8f0f70df8c8b09b33"
-  integrity sha512-SgZmjJSCB4Ho/45NzjQMgfpLhgIVHdwNg/mfoNjqHymcCx7NpiUHfrkd3ZqnbvchREYgjDpRzFAGoiapiwXJUQ==
-  dependencies:
-    nanoid "^2.0.4"
-    puppeteer-core "^1.17.0"
-    tracium "^0.2.1"
-    yargs "^14.0.0"
-
 estimo@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/estimo/-/estimo-2.0.0.tgz#fc926935831848f69d0ddee3f686b2f561fa2c3c"
@@ -9968,7 +9931,7 @@ file-loader@^3.0.1:
     loader-utils "^1.0.2"
     schema-utils "^1.0.0"
 
-file-loader@^4.1.0, file-loader@^4.2.0:
+file-loader@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-4.2.0.tgz#5fb124d2369d7075d70a9a5abecd12e60a95215e"
   integrity sha512-+xZnaK5R8kBJrHK0/6HRlrKNamvVS5rjyuju+rnyxRGuwUJwpAMsVzUl5dz6rK8brkzjV6JpcFNjp6NqV0g1OQ==
@@ -11462,7 +11425,7 @@ gzip-size@5.0.0:
     duplexer "^0.1.1"
     pify "^3.0.0"
 
-gzip-size@5.1.1, gzip-size@^5.0.0, gzip-size@^5.1.1:
+gzip-size@5.1.1, gzip-size@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-5.1.1.tgz#cb9bee692f87c0612b232840a873904e4c135274"
   integrity sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==
@@ -19654,7 +19617,7 @@ react-wait@^0.3.0:
   resolved "https://registry.yarnpkg.com/react-wait/-/react-wait-0.3.0.tgz#0cdd4d919012451a5bc3ab0a16d00c6fd9a8c10b"
   integrity sha512-kB5x/kMKWcn0uVr9gBdNz21/oGbQwEQnF3P9p6E9yLfJ9DRcKS0fagbgYMFI0YFOoyKDj+2q6Rwax0kTYJF37g==
 
-react@16.8.6, react@16.9.0, react@^0.14.0, react@^16.8.0, react@^16.8.3, react@^16.8.6, react@^16.9.0:
+react@16.9.0, react@^0.14.0, react@^16.8.0, react@^16.8.3, react@^16.8.6, react@^16.9.0:
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.9.0.tgz#40ba2f9af13bc1a38d75dbf2f4359a5185c4f7aa"
   integrity sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==
@@ -20930,7 +20893,7 @@ sentence-case@^2.1.0:
     no-case "^2.2.0"
     upper-case-first "^1.1.2"
 
-serialize-javascript@^1.4.0, serialize-javascript@^1.7.0:
+serialize-javascript@^1.7.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"
   integrity sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
@@ -21183,32 +21146,6 @@ sitemap@^1.13.0:
   dependencies:
     underscore "^1.7.0"
     url-join "^1.1.0"
-
-size-limit@1.3.8:
-  version "1.3.8"
-  resolved "https://registry.yarnpkg.com/size-limit/-/size-limit-1.3.8.tgz#6befc90e3af972377aa6eb8046f788fe8e74eae8"
-  integrity sha512-EVzbNtbtlaEJlDV8paGZwH2TLjUMAx6NtFHb23mQ9AJna+XGgifxxjrAlNhlF7Kiv+Ts8vjUbgF4Vj/eBqCuWw==
-  dependencies:
-    bytes "^3.1.0"
-    chalk "^2.4.2"
-    ci-job-number "^0.3.0"
-    compression-webpack-plugin "^3.0.0"
-    cosmiconfig "^5.2.1"
-    css-loader "^3.1.0"
-    del "^5.0.0"
-    escape-string-regexp "^2.0.0"
-    estimo "^1.1.3"
-    file-loader "^4.1.0"
-    globby "^10.0.1"
-    gzip-size "^5.1.1"
-    make-dir "^3.0.0"
-    optimize-css-assets-webpack-plugin "^5.0.3"
-    react "16.8.6"
-    read-pkg-up "^6.0.0"
-    style-loader "^0.23.1"
-    webpack "^4.38.0"
-    webpack-bundle-analyzer "^3.3.2"
-    yargs "^13.3.0"
 
 size-limit@2.1.6:
   version "2.1.6"
@@ -22774,6 +22711,25 @@ tslint@5.14.0:
     tslib "^1.8.0"
     tsutils "^2.29.0"
 
+tslint@5.20.0:
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.20.0.tgz#fac93bfa79568a5a24e7be9cdde5e02b02d00ec1"
+  integrity sha512-2vqIvkMHbnx8acMogAERQ/IuINOq6DFqgF8/VDvhEkBqQh/x6SP0Y+OHnKth9/ZcHQSroOZwUQSN18v8KKF0/g==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    builtin-modules "^1.1.1"
+    chalk "^2.3.0"
+    commander "^2.12.1"
+    diff "^4.0.1"
+    glob "^7.1.1"
+    js-yaml "^3.13.1"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
+    resolve "^1.3.2"
+    semver "^5.3.0"
+    tslib "^1.8.0"
+    tsutils "^2.29.0"
+
 tslint@^5.9.1:
   version "5.18.0"
   resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.18.0.tgz#f61a6ddcf372344ac5e41708095bbf043a147ac6"
@@ -23741,7 +23697,7 @@ webpack-assets-manifest@^3.1.1:
     tapable "^1.0.0"
     webpack-sources "^1.0.0"
 
-webpack-bundle-analyzer@^3.3.2, webpack-bundle-analyzer@^3.5.0:
+webpack-bundle-analyzer@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.5.0.tgz#c82130a490a05f9267aa5956871aef574dff5074"
   integrity sha512-NzueflueLSJxWGzDlMq5oUV+P8Qoq6yiaQlXGCbDYUpHEKlmzWdPLBJ4k/B6HTdAP/vHM8ply1Fx08mDnY+S8Q==


### PR DESCRIPTION
I've added an HTML serializer for the Jest tests to make it easier to update the tests without having to go through and edit each one (in future). I've used prettier to format the HTML so it's easier to read, but I'm not yet sure that my indentation code is correct. I've also added `const FIRST_PARAGRAPH_SELECTOR = EDITOR_CLASS_SELECTOR + ' > p:first-child';` so that we get the content of the first paragraph since we don't care about the `<p>` tag itself in our tests; I'm not sure if this should be moved to a more central location like `@remirror/core` or not?

The test looks very similar to before, but it factors in more of the content and it can auto-update, so I'm calling that a win :grin: 

```diff
 it('should have a social editor', async () => {
      await $editor.focus();
      await $editor.type('This is text https://url.com');
-     await expect(innerHtml(EDITOR_CLASS_SELECTOR)).resolves.toInclude(
-       '<a href="https://url.com" role="presentation">https://url.com</a>',
+     expect($innerHTML(FIRST_PARAGRAPH_SELECTOR)).resolves.toMatchInlineSnapshot(
+       `This is text <a href="http://url.com" role="presentation">https://url.com</a>`,
      );
    });
```

If we need to use jest.retryTimes then we need to alias our inline snapshots, so hopefully we can avoid that.