### PR TITLE
Install `git-lfs` in Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,7 +10,8 @@ ports:
   - port: 3000
   - port: 3001
 tasks:
-  - init: yarn
+  - before: brew install git-lfs
+    init: yarn
     command: yarn storybook
 
 vscode:


### PR DESCRIPTION
## Description

Hi @ifiokjr! Thanks for reporting the [Git LFS problem in Gitpod](https://spectrum.chat/gitpod/general/adding-git-lfs-support~541f4de1-a708-42ef-a136-acac2448b49f).

I wasn't able to reproduce this bug, but I noticed that installing `git-lfs` itself can be easily done with `brew install git-lfs`. Hopefully this PR can resolve your problem.

We can also install `git-lfs` by default in all Gitpod workspaces, so that you don't need to do it here.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**][contributing] document.
- [x] My code follows the code style of this project and `yarn fix` runs successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `yarn test` .

[contributing]: https://github.com/ifiokjr/remirror/blob/master/docs/pages/contributing.md


<a href="https://gitpod.io/#https://github.com/ifiokjr/remirror/pull/159"><img src="https://gitpod.io/api/apps/github/pbs/github.com/jankeromnes/remirror.git/f946e045b5209b394ecb02deed4d015cc7e8b864.svg" /></a>

