### PR TITLE
ci: cache yarn and preserve the build across jobs

### DIFF
--- a/.artifactignore
+++ b/.artifactignore
@@ -1,0 +1,10 @@
+**/*
+
+## Build artifacts
+!@remirror/*/lib/**
+!@packages/*/lib/**
+!@remirror/*/lib
+!packages/*/lib
+
+## Failed Diffs
+!e2e/__failed-diffs__

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,7 +11,6 @@ ports:
   - port: 3001
 tasks:
   - init: yarn
-    command: yarn storybook
 
 vscode:
   extensions:
@@ -30,8 +29,8 @@ github:
     # add a check to pull requests (defaults to true)
     addCheck: true
     # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
-    addComment: false
+    addComment: true
     # add a "Review in Gitpod" button to the pull request's description (defaults to false)
-    addBadge: true
+    addBadge: false
     # add a label once the prebuild is ready to pull requests (defaults to false)
     addLabel: false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,10 +7,22 @@
   "eslint.lintTask.enable": true,
   "eslint.lintTask.options": "--ext .js,.jsx,.ts,.tsx .",
   "eslint.validate": [
-    { "autoFix": true, "language": "javascript" },
-    { "autoFix": true, "language": "javascriptreact" },
-    { "autoFix": true, "language": "typescript" },
-    { "autoFix": true, "language": "typescriptreact" },
+    {
+      "autoFix": true,
+      "language": "javascript"
+    },
+    {
+      "autoFix": true,
+      "language": "javascriptreact"
+    },
+    {
+      "autoFix": true,
+      "language": "typescript"
+    },
+    {
+      "autoFix": true,
+      "language": "typescriptreact"
+    },
   ],
   "search.exclude": {
     "docs/api": true,
@@ -26,5 +38,6 @@
   "files.insertFinalNewline": true,
   "files.trimTrailingWhitespace": true,
   "javascript.format.enable": false,
-  "typescript.format.enable": false
+  "typescript.format.enable": false,
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/package.json
+++ b/package.json
@@ -35,15 +35,16 @@
     "fix": "run-s fix:prettier fix:pkgjson fix:es",
     "fix:es": "yarn lint:es --fix",
     "fix:pkgjson": "node support/scripts/package-json-prettier.js",
-    "fix:prettier": "prettier --write \"**/*.{json,yml,yaml,md,mdx,js,tsx,ts}\" \"!docs/api/**\" \"!support/api/**\" \"!**/temp/**\"",
+    "fix:prettier": "prettier --write \"**/*.{json,yml,yaml,md,mdx}\" \"!docs/api/**\" \"!support/api/**\" \"!**/temp/**\"",
     "frozen": "yarn --frozen-lockfile install",
     "generate:all": "node support/scripts/generate-api-docs.js --all",
     "generate:api": "node support/scripts/generate-api-docs.js --api",
     "generate:docs": "node support/scripts/generate-api-docs.js --docs",
     "generate:json": "node support/scripts/generate-configs.js",
     "if-clean": "node support/scripts/run-if-clean.js",
+    "if-not-ci": "node support/scripts/run-if-not-ci.js",
     "if-config": "node support/scripts/run-if-config.js",
-    "postinstall": "run-s build:cli build:cli:ts",
+    "postinstall": "yarn if-not-ci run-s build:cli build:cli:ts",
     "integrity": "yarn check --integrity",
     "lerna:publish:canary": "lerna publish prerelease --preid=canary --dist-tag next --exact --force-publish && release --pre",
     "lerna:publish:ci": "lerna publish -y --canary --preid=ci.$(date +%s) --dist-tag ci",
@@ -186,7 +187,7 @@
       "post-commit": "echo $HUSKY_GIT_STDIN | support/git-hooks/post-commit-lfs $HUSKY_GIT_PARAMS",
       "post-merge": "echo $HUSKY_GIT_STDIN | support/git-hooks/post-merge-lfs $HUSKY_GIT_PARAMS",
       "pre-commit": "yarn if-config hooks.preCommit lint-staged",
-      "pre-push": "echo $HUSKY_GIT_STDIN | support/git-hooks/pre-push-lfs $HUSKY_GIT_PARAMS && yarn if-config hooks.prePush yarn audit && yarn checks"
+      "pre-push": "echo $HUSKY_GIT_STDIN | support/git-hooks/pre-push-lfs $HUSKY_GIT_PARAMS && yarn if-config hooks.prePush \"yarn audit && yarn checks\""
     }
   },
   "jest": {

--- a/support/azure/azure-pipelines.yml
+++ b/support/azure/azure-pipelines.yml
@@ -1,3 +1,6 @@
+variables:
+  ci: 'true'
+
 jobs:
   - template: pipeline-jobs.yml
     parameters:

--- a/support/azure/pipeline-jobs.yml
+++ b/support/azure/pipeline-jobs.yml
@@ -27,19 +27,35 @@ jobs:
             displayName: 'Run unit tests across project'
 
   - ${{ if eq(parameters.name, 'Linux') }}:
-      - job: ${{ parameters.name }}SizeChecks
+      - job: ${{ parameters.name }}Build
         pool:
           vmImage: ${{ parameters.vmImage }}
         steps:
           - template: pipeline-yarn-install.yml
-          - bash: yarn build:rollup
-            displayName: 'Build project'
+          - bash: yarn build
+            displayName: 'Build all project dependencies'
+          - publish: $(System.DefaultWorkingDirectory)/
+            condition: succeeded()
+            artifact: Build
+            displayName: Create build artifact
+
+  - ${{ if eq(parameters.name, 'Linux') }}:
+      - job: ${{ parameters.name }}SizeChecks
+        pool:
+          vmImage: ${{ parameters.vmImage }}
+        dependsOn:
+          - LinuxBuild
+        steps:
+          - template: pipeline-yarn-install.yml
+          - template: pipeline-restore-build.yml
           - bash: yarn size
             displayName: 'Check size limits'
 
   - job: ${{ parameters.name }}ChromeIntegrationTests
     pool:
       vmImage: ${{ parameters.vmImage }}
+    dependsOn:
+      - LinuxBuild
     steps:
       - checkout: self
         lfs: true
@@ -47,15 +63,11 @@ jobs:
           - bash: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
             displayName: 'Increase file watch limit for Linux only'
       - template: pipeline-yarn-install.yml
-
-      - bash: yarn build
-        displayName: 'Build project'
-
+      - template: pipeline-restore-build.yml
       - bash: yarn test:e2e
         displayName: 'Razzle integration tests'
         env:
           REMIRROR_E2E_SERVER: razzle
-
       - publish: $(System.DefaultWorkingDirectory)/e2e/__failed-diffs__
         condition: failed()
         artifact: ImageSnapshots
@@ -74,8 +86,7 @@ jobs:
           vmImage: ${{ parameters.vmImage }}
         steps:
           - template: pipeline-yarn-install.yml
-          - bash: yarn build
-            displayName: 'Build project'
+          - template: pipeline-restore-build.yml
           - bash: echo "//registry.npmjs.org/:_authToken=\${NPM_AUTH_TOKEN}" > .npmrc 2> /dev/null
             displayName: Authenticate npm for lerna
             env:

--- a/support/azure/pipeline-restore-build.yml
+++ b/support/azure/pipeline-restore-build.yml
@@ -1,0 +1,7 @@
+steps:
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      artifact: Build
+      patterns: '**'
+      path: $(Build.SourcesDirectory)
+    displayName: 'Restore build artifact'

--- a/support/azure/pipeline-yarn-install.yml
+++ b/support/azure/pipeline-yarn-install.yml
@@ -3,6 +3,11 @@ steps:
     inputs:
       versionSpec: '10.x'
     displayName: 'Install Node.js'
+  # - task: CacheBeta@1
+  #   inputs:
+  #     key: yarn | $(Agent.OS) | yarn.lock
+  #     path: $(Pipeline.Workspace)/.yarn
+  #   displayName: Cache Yarn packages
   - bash: yarn audit
     displayName: 'Check for vulnerabilities'
   - bash: yarn ci

--- a/support/scripts/helpers/read-config.js
+++ b/support/scripts/helpers/read-config.js
@@ -22,7 +22,7 @@ const readJSON = str => {
 exports.readConfigFile = () => {
   if (!existsSync(configFilePath)) {
     console.log('No .config.json file');
-    return;
+    return {};
   }
 
   const fileContents = readFileSync(configFilePath).toString();

--- a/support/scripts/run-if-config.js
+++ b/support/scripts/run-if-config.js
@@ -10,4 +10,7 @@ const value = readProperty({ property });
 if (value) {
   console.log('Opted into husky checks... 😋');
   execSync(command, { stdio: 'inherit' });
+} else {
+  console.log('Ignoring checks');
+  process.exit(0);
 }

--- a/support/scripts/run-if-not-ci.js
+++ b/support/scripts/run-if-not-ci.js
@@ -1,0 +1,12 @@
+const { execSync } = require('child_process');
+
+const [, , ...args] = process.argv;
+const command = args.join(' ');
+const { CI } = process.env;
+
+if (CI === 'true') {
+  console.log(`CI='true' - skipping command: '${command}'\n\n`);
+  process.exit(0);
+}
+
+execSync(command, { stdio: 'inherit' });


### PR DESCRIPTION
## Description

- Add caching for yarn to the pipelines ❌[issue](https://github.com/microsoft/azure-pipelines-tasks/issues/11259#issuecomment-535304299)
- Save build artifact for reuse across pipelines

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**][contributing] document.
- [x] My code follows the code style of this project and `yarn fix` runs successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `yarn test` .

[contributing]: https://github.com/ifiokjr/remirror/blob/master/docs/pages/contributing.md


<a href="https://gitpod.io/#https://github.com/ifiokjr/remirror/pull/161"><img src="https://gitpod.io/api/apps/github/pbs/github.com/ifiokjr/remirror.git/f21331dd3335b7aa63028dfaa13e4c5c6f2ca64a.svg" /></a>

