### PR TITLE
typo correction

### DIFF
--- a/docs/pages/guides/quickstart.mdx
+++ b/docs/pages/guides/quickstart.mdx
@@ -28,4 +28,4 @@ export const MyWorldClassEditor = () => {
 };
 ```
 
-So that's a taster of a simplified `Remirror` editor setup.
+So that's a taste of a simplified `Remirror` editor setup.


### PR DESCRIPTION
## Description

Removed an `r` which appears to have been typed by mistake along with the `e` in `taste`.

Note: I originally sought to update the published documentation to change extension references from `Bold` to `BoldExtension` (for example); however, I saw they were already updated in the canary branch and need to be published.

## Checklist

- [x] I have read the [**contributing**][contributing] document.
- [x] My code follows the code style of this project and `yarn fix` runs successfully.
- [x] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `yarn test` .

## Screenshots

N/A

[contributing]: https://github.com/ifiokjr/remirror/blob/master/docs/pages/contributing.md