### PR TITLE
feat: serializer-extension to enable app to save editor state

### DIFF
--- a/@remirror/core-extensions/src/extensions/index.ts
+++ b/@remirror/core-extensions/src/extensions/index.ts
@@ -6,5 +6,6 @@ export * from './history-extension';
 export * from './node-cursor-extension';
 export * from './placeholder-extension';
 export * from './position-tracker-extension';
+export * from './serializer-extension';
 export * from './ssr-helpers-extension';
 export * from './trailing-node-extension';

--- a/@remirror/core-extensions/src/extensions/serializer-extension.ts
+++ b/@remirror/core-extensions/src/extensions/serializer-extension.ts
@@ -27,10 +27,6 @@ export class SerializerExtension extends Extension<SerializerExtensionOptions> {
     return 'serializer' as const;
   }
 
-  get defaultOptions() {
-    return {};
-  }
-
   public keys({ getActions }: ExtensionManagerParams) {
     return {
       'Mod-s': () => {

--- a/@remirror/core-extensions/src/extensions/serializer-extension.ts
+++ b/@remirror/core-extensions/src/extensions/serializer-extension.ts
@@ -1,0 +1,50 @@
+import {
+  BaseExtensionOptions,
+  CommandFunction,
+  EditorState,
+  Extension,
+  ExtensionManagerParams,
+} from '@remirror/core';
+
+/**
+ * SerializerHandler establishes the signature of a callback function called when the Serialize Extension
+ * action is triggered.
+ */
+export type SerializerHandler = (state: EditorState) => boolean;
+
+/**
+ * SerializerExtensionOptions defines the options for the SerializerExtension.
+ */
+export interface SerializerExtensionOptions extends BaseExtensionOptions {
+  onSerialize: SerializerHandler;
+}
+
+/**
+ * SerializerExtension
+ */
+export class SerializerExtension extends Extension<SerializerExtensionOptions> {
+  get name() {
+    return 'serializer' as const;
+  }
+
+  get defaultOptions() {
+    return {};
+  }
+
+  public keys({ getActions }: ExtensionManagerParams) {
+    return {
+      'Mod-s': () => {
+        getActions('serializeState')();
+        return true;
+      },
+    };
+  }
+
+  public commands() {
+    return {
+      serializeState: (): CommandFunction => (state, _) => {
+        return this.options.onSerialize(state);
+      },
+    };
+  }
+}

--- a/@remirror/editor-wysiwyg/src/components/wysiwyg-editor.tsx
+++ b/@remirror/editor-wysiwyg/src/components/wysiwyg-editor.tsx
@@ -138,11 +138,20 @@ export const WysiwygEditor: FC<WysiwygEditorProps> = ({
  * Any component rendered has access to the remirror context.
  */
 const InnerEditor: FC<BubbleMenuProps> = ({ linkActivated, deactivateLink, activateLink }) => {
-  const { getRootProps } = useRemirrorContext<WysiwygExtensions>();
+  const { getRootProps, actions } = useRemirrorContext<WysiwygExtensions>();
 
   return (
     <EditorWrapper>
       <MenuBar activateLink={activateLink} />
+      <div>
+        <button
+          onClick={() => {
+            actions['serializeState']();
+          }}
+        >
+          Save
+        </button>
+      </div>
       <BubbleMenu linkActivated={linkActivated} deactivateLink={deactivateLink} activateLink={activateLink} />
       <div {...getRootProps()} data-testid='remirror-wysiwyg-editor' />
     </EditorWrapper>

--- a/@remirror/editor-wysiwyg/src/components/wysiwyg-editor.tsx
+++ b/@remirror/editor-wysiwyg/src/components/wysiwyg-editor.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 
 import { jsx } from '@emotion/core';
-import { deepMerge, RemirrorTheme, EditorState } from '@remirror/core';
+import { deepMerge, RemirrorTheme } from '@remirror/core';
 import {
   BlockquoteExtension,
   BoldExtension,
@@ -101,15 +101,7 @@ export const WysiwygEditor: FC<WysiwygEditorProps> = ({
         <RemirrorExtension Constructor={OrderedListExtension} />
         <RemirrorExtension Constructor={HardBreakExtension} />
         <RemirrorExtension Constructor={TrailingNodeExtension} />
-        <RemirrorExtension
-          Constructor={SerializerExtension}
-          onSerialize={(s: EditorState) => {
-            // todo: modify the wysiwyg options to allow this callback to be provided by
-            // the view rendering the editor.
-            console.log('serialized state', s.toJSON());
-            return true;
-          }}
-        />
+        <RemirrorExtension Constructor={SerializerExtension} onSerialize={props.onSerialization} />
         <RemirrorExtension
           Constructor={CodeBlockExtension}
           supportedLanguages={supportedLanguages}

--- a/@remirror/editor-wysiwyg/src/components/wysiwyg-editor.tsx
+++ b/@remirror/editor-wysiwyg/src/components/wysiwyg-editor.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 
 import { jsx } from '@emotion/core';
-import { deepMerge, RemirrorTheme } from '@remirror/core';
+import { deepMerge, RemirrorTheme, EditorState } from '@remirror/core';
 import {
   BlockquoteExtension,
   BoldExtension,
@@ -16,6 +16,7 @@ import {
   OrderedListExtension,
   ParagraphExtension,
   PlaceholderExtension,
+  SerializerExtension,
   SSRHelperExtension,
   StrikeExtension,
   TrailingNodeExtension,
@@ -100,6 +101,15 @@ export const WysiwygEditor: FC<WysiwygEditorProps> = ({
         <RemirrorExtension Constructor={OrderedListExtension} />
         <RemirrorExtension Constructor={HardBreakExtension} />
         <RemirrorExtension Constructor={TrailingNodeExtension} />
+        <RemirrorExtension
+          Constructor={SerializerExtension}
+          onSerialize={(s: EditorState) => {
+            // todo: modify the wysiwyg options to allow this callback to be provided by
+            // the view rendering the editor.
+            console.log('serialized state', s.toJSON());
+            return true;
+          }}
+        />
         <RemirrorExtension
           Constructor={CodeBlockExtension}
           supportedLanguages={supportedLanguages}

--- a/@remirror/editor-wysiwyg/src/wysiwyg-types.ts
+++ b/@remirror/editor-wysiwyg/src/wysiwyg-types.ts
@@ -13,6 +13,7 @@ import {
   ListItemExtension,
   OrderedListExtension,
   ParagraphExtension,
+  SerializerExtension,
   SSRHelperExtension,
   StrikeExtension,
   TrailingNodeExtension,
@@ -48,6 +49,7 @@ export type WysiwygExtensions =
   | ListItemExtension
   | OrderedListExtension
   | ParagraphExtension
+  | SerializerExtension
   | SSRHelperExtension
   | StrikeExtension
   | TrailingNodeExtension

--- a/@remirror/editor-wysiwyg/src/wysiwyg-types.ts
+++ b/@remirror/editor-wysiwyg/src/wysiwyg-types.ts
@@ -14,6 +14,7 @@ import {
   OrderedListExtension,
   ParagraphExtension,
   SerializerExtension,
+  SerializerHandler,
   SSRHelperExtension,
   StrikeExtension,
   TrailingNodeExtension,
@@ -86,6 +87,12 @@ export interface WysiwygEditorProps
    * Extend the theme with your own styles
    */
   theme?: Partial<RemirrorTheme>;
+
+  /**
+   * onSerialization is a callback to capture editor state and is triggered
+   * when a serialization command is issued.
+   */
+  onSerialization: SerializerHandler;
 }
 
 export type ButtonProps = JSX.IntrinsicElements['button'] & {


### PR DESCRIPTION
## Description

This pull request shares a simple extension that can allow a host application to serialize the editor state. This pull request is submitted in a draft state to solicit feedback and guidance.

* `Mod+s` key triggers the serialization callback
* A crude button has been added to wysiwyg inner editor (needs cleanup)
* SerializerExtension provides `onSerialize` callback which can be exposed to host application
* wysiwyg editor exposes an `onSerialize` function to allow the host application to process the editor state (e.g., save to server)

Known issues:

* UI button to trigger the serialization command is crude and needs to fold into the toolbar/menu probably using a "Save" (floppy disc) icon
* Snapshot tests are failing (and perhaps others)
* Examples of wysiwyg editor do not implement the serializer handler function

Additional Scope

If accepted, I also propose this PR include updating the wysiwyg showcase to persist the state in [sessionStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage) and reload that state after a refresh if it exists.

## Checklist

- [x] I have read the [**contributing**][contributing] document.
- [ ] My code follows the code style of this project and `yarn fix` runs successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `yarn test` .

## Screenshots

Not Yet Relevant

[contributing]: https://github.com/ifiokjr/remirror/blob/master/docs/pages/contributing.md
