### PR TITLE
feat: remove deprecated methods

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,6 +31,7 @@ module.exports = {
     'prettier/react',
   ],
   plugins: [
+    'simple-import-sort',
     'jest',
     '@typescript-eslint',
     'react-hooks',
@@ -60,7 +61,7 @@ module.exports = {
     es6: true,
   },
   rules: {
-    eqeqeq: ['warn', 'always', { null: 'ignore' }],
+    eqeqeq: ['error', 'always', { null: 'ignore' }],
     'unicorn/filename-case': ['error', { case: 'kebabCase' }],
     'default-case': 'warn',
 
@@ -94,17 +95,24 @@ module.exports = {
     'react-hooks/rules-of-hooks': 'error',
 
     'import/no-deprecated': 'warn',
-    'import/first': 'warn',
+    'import/first': 'error',
     'import/no-duplicates': 'error',
     'import/no-cycle': 'error',
     'import/no-self-import': 'error',
-    'import/newline-after-import': 'warn',
+    'import/newline-after-import': 'error',
+    'import/order': 'off',
+
+    'simple-import-sort/sort': 'error',
+    'sort-imports': 'off',
 
     // ESLint rules (those without a '/' in) come after here
 
     'no-nested-ternary': 'off', // Prettier makes nested ternaries more acceptable
     'no-return-assign': ['error', 'except-parens'],
-    'no-unused-expressions': ['error', { allowTernary: true }],
+    '@typescript-eslint/no-unused-expressions': [
+      'error',
+      { allowTernary: true, allowShortCircuit: true },
+    ],
     'prefer-arrow-callback': ['error', { allowNamedFunctions: true }],
 
     // Temporarily disabled rules (please re-enable these!):
@@ -113,7 +121,7 @@ module.exports = {
     '@typescript-eslint/no-inferrable-types': 'off',
     '@typescript-eslint/no-namespace': 'off', // Migrate all the global namespaces to be in .d.ts files (see overrides)
     '@typescript-eslint/no-non-null-assertion': 'warn',
-    '@typescript-eslint/no-use-before-define': 'warn',
+    '@typescript-eslint/no-use-before-define': ['warn', { typedefs: false }],
     '@typescript-eslint/no-unused-vars': [
       'warn',
       {
@@ -165,7 +173,7 @@ module.exports = {
         '@typescript-eslint/no-var-requires': 'error',
         '@typescript-eslint/restrict-template-expressions': [
           'warn',
-          { allowNumber: true },
+          { allowNumber: true, allowBoolean: true },
         ],
         '@typescript-eslint/no-dynamic-delete': ['error'],
         '@typescript-eslint/camelcase': [
@@ -199,7 +207,7 @@ module.exports = {
       rules: {
         '@typescript-eslint/no-namespace': 'off',
         '@typescript-eslint/no-unused-vars': 'off',
-        'no-unused-expressions': 'off',
+        '@typescript-eslint/no-unused-expressions': 'off',
       },
     },
   ],

--- a/@remirror/cli/src/commands/bundle/cli-components.tsx
+++ b/@remirror/cli/src/commands/bundle/cli-components.tsx
@@ -3,6 +3,7 @@ import { Box, Color, Text } from 'ink';
 import Spinner from 'ink-spinner';
 import React, { FC, useEffect } from 'react';
 import useSetState from 'react-use/lib/useSetState';
+
 import { msToDuration } from '../cli-utils';
 import { BundleArgv } from './cli-types';
 

--- a/@remirror/cli/src/commands/bundle/cli-parcel.ts
+++ b/@remirror/cli/src/commands/bundle/cli-parcel.ts
@@ -6,6 +6,7 @@ import Bundler, { ParcelOptions } from 'parcel-bundler';
 import path from 'path';
 import rimraf from 'rimraf';
 import util from 'util';
+
 import { BundleArgv } from './cli-types';
 
 const REMIRROR_ID = '__remirror';

--- a/@remirror/cli/src/commands/bundle/index.tsx
+++ b/@remirror/cli/src/commands/bundle/index.tsx
@@ -1,6 +1,7 @@
 import { render } from 'ink';
 import React from 'react';
 import { CommandModule } from 'yargs';
+
 import { Bundle } from './cli-components';
 import { bundleFile } from './cli-parcel';
 import { BundleArgv } from './cli-types';

--- a/@remirror/cli/src/index.ts
+++ b/@remirror/cli/src/index.ts
@@ -1,7 +1,8 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
 import yargs from 'yargs';
+
 import { bundle } from './commands/bundle';
 
-// eslint-disable-next-line no-unused-expressions
 yargs
   .usage('Usage: $0 <cmd> [options]')
   .command(bundle)

--- a/@remirror/core-extensions/src/__tests__/core-extensions.spec.ts
+++ b/@remirror/core-extensions/src/__tests__/core-extensions.spec.ts
@@ -1,4 +1,5 @@
 import { isExtension } from '@remirror/core';
+
 import { baseExtensions } from '../core-extensions';
 
 test('baseExtensions', () => {

--- a/@remirror/core-extensions/src/core-extensions.ts
+++ b/@remirror/core-extensions/src/core-extensions.ts
@@ -1,4 +1,5 @@
 import { DocExtension, InferFlexibleExtensionList, TextExtension } from '@remirror/core';
+
 import {
   BaseKeymapExtension,
   CompositionExtension,

--- a/@remirror/core-extensions/src/extensions/__tests__/history-extension.spec.ts
+++ b/@remirror/core-extensions/src/extensions/__tests__/history-extension.spec.ts
@@ -1,4 +1,6 @@
+import { EditorState } from '@remirror/core';
 import { renderEditor } from 'jest-remirror';
+
 import { HistoryExtension } from '../history-extension';
 
 describe('commands', () => {
@@ -17,6 +19,7 @@ describe('commands', () => {
         expect(content.state.doc).toEqualRemirrorDocument(doc(p('')));
       });
   });
+
   it('can redo', () => {
     const { p, doc, add } = create();
     add(doc(p('<cursor>')))
@@ -34,29 +37,42 @@ describe('commands', () => {
       });
   });
 });
+
 describe('`getState` and `getDispatch`', () => {
   const dispatcher = jest.fn();
+  let state: EditorState;
+  const getState: () => EditorState = jest.fn(() => state);
   const mocks = {
-    getState: jest.fn(),
+    getState,
     getDispatch: () => dispatcher,
   };
 
   const create = () => renderEditor({ others: [new HistoryExtension(mocks)] });
+  let { p, doc, add } = create();
+
+  beforeEach(() => {
+    ({ p, doc, add } = create());
+  });
+
   it('overrides for undo', () => {
-    const { p, doc, add } = create();
     add(doc(p('<cursor>')))
       .insertText('Text goes here')
+      .callback(content => {
+        state = content.state;
+      })
       .actionsCallback(actions => {
         actions.undo();
-        expect(mocks.getState).toHaveBeenCalled();
-        expect(dispatcher).toHaveBeenCalled();
+        expect(mocks.getState).toHaveBeenCalledTimes(1);
+        expect(dispatcher).toHaveBeenCalledTimes(1);
       });
   });
 
   it('overrides for redo', () => {
-    const { p, doc, add } = create();
     add(doc(p('<cursor>')))
       .insertText('Text goes here')
+      .callback(content => {
+        state = content.state;
+      })
       .actionsCallback(actions => {
         actions.undo();
         jest.clearAllMocks();
@@ -70,6 +86,9 @@ describe('`getState` and `getDispatch`', () => {
     add(doc(p('<cursor>')))
       .insertText('Text goes here')
       .shortcut('Mod-z')
+      .callback(content => {
+        state = content.state;
+      })
       .callback(() => {
         expect(mocks.getState).toHaveBeenCalledTimes(1);
         expect(dispatcher).toHaveBeenCalledTimes(1);

--- a/@remirror/core-extensions/src/extensions/__tests__/position-tracker-extension.spec.ts
+++ b/@remirror/core-extensions/src/extensions/__tests__/position-tracker-extension.spec.ts
@@ -1,5 +1,6 @@
 import { ExtensionMap } from '@remirror/test-fixtures';
 import { renderEditor } from 'jest-remirror';
+
 import { PositionTrackerExtension, PositionTrackerExtensionOptions } from '../position-tracker-extension';
 
 const { heading: headingNode, blockquote: blockquoteNode } = ExtensionMap.nodes;

--- a/@remirror/core-extensions/src/extensions/__tests__/trailing-node-extension.spec.ts
+++ b/@remirror/core-extensions/src/extensions/__tests__/trailing-node-extension.spec.ts
@@ -1,5 +1,6 @@
 import { ExtensionMap } from '@remirror/test-fixtures';
 import { renderEditor } from 'jest-remirror';
+
 import { TrailingNodeExtension, TrailingNodeExtensionOptions } from '../trailing-node-extension';
 
 const { heading: headingNode, blockquote: blockquoteNode } = ExtensionMap.nodes;

--- a/@remirror/core-extensions/src/extensions/composition/composition-extension.ts
+++ b/@remirror/core-extensions/src/extensions/composition/composition-extension.ts
@@ -1,5 +1,6 @@
 import { Extension } from '@remirror/core';
 import { ProsemirrorPlugin } from '@remirror/core-types';
+
 import { NODE_CURSOR_DEFAULTS } from '../../core-extension-constants';
 import { CompositionExtensionOptions } from '../../core-extension-types';
 import { createCompositionPlugin } from './composition-plugin';

--- a/@remirror/core-extensions/src/extensions/composition/composition-plugin.ts
+++ b/@remirror/core-extensions/src/extensions/composition/composition-plugin.ts
@@ -3,6 +3,7 @@ import { Cast, isAndroidOS } from '@remirror/core-helpers';
 import { EditorView } from '@remirror/core-types';
 import { getPluginState, isTextSelection, nodeNameMatchesList } from '@remirror/core-utils';
 import { Plugin, Selection } from 'prosemirror-state';
+
 import { CompositionExtensionOptions, InputEvent } from '../../core-extension-types';
 import { CompositionState } from './composition-state';
 

--- a/@remirror/core-extensions/src/extensions/gap-cursor-extension.ts
+++ b/@remirror/core-extensions/src/extensions/gap-cursor-extension.ts
@@ -1,7 +1,7 @@
 import { Extension } from '@remirror/core';
 import { isInstanceOf } from '@remirror/core-helpers';
 import { css } from '@remirror/react-utils';
-import { gapCursor, GapCursor } from 'prosemirror-gapcursor';
+import { GapCursor, gapCursor } from 'prosemirror-gapcursor';
 
 /**
  * Create a gap cursor plugin.

--- a/@remirror/core-extensions/src/extensions/history-extension.ts
+++ b/@remirror/core-extensions/src/extensions/history-extension.ts
@@ -1,4 +1,4 @@
-import { Extension } from '@remirror/core';
+import { Extension, isFunction } from '@remirror/core';
 import {
   BaseExtensionOptions,
   CommandFunction,
@@ -79,11 +79,10 @@ export class HistoryExtension extends Extension<HistoryExtensionOptions> {
     return (state, dispatch, view) => {
       const { getState, getDispatch } = this.options;
 
-      return method(
-        getState ? getState() || state : state,
-        getDispatch ? getDispatch() || dispatch : dispatch,
-        view,
-      );
+      const wrappedState = isFunction(getState) ? getState() : state;
+      const wrappedDispatch = isFunction(getDispatch) ? getDispatch() : dispatch;
+
+      return method(wrappedState, wrappedDispatch, view);
     };
   };
 

--- a/@remirror/core-extensions/src/extensions/node-cursor-extension.ts
+++ b/@remirror/core-extensions/src/extensions/node-cursor-extension.ts
@@ -1,11 +1,11 @@
 import {
-  Extension,
   BaseExtensionOptions,
+  Extension,
+  ExtensionManagerParams,
   NodeMatch,
   ResolvedPos,
-  ExtensionManagerParams,
-  ZERO_WIDTH_SPACE_CHAR,
   uniqueArray,
+  ZERO_WIDTH_SPACE_CHAR,
 } from '@remirror/core';
 import { getPluginState, nodeNameMatchesList } from '@remirror/core-utils';
 import { EditorState, Plugin, Transaction } from 'prosemirror-state';

--- a/@remirror/core-extensions/src/extensions/placeholder/placeholder-extension.ts
+++ b/@remirror/core-extensions/src/extensions/placeholder/placeholder-extension.ts
@@ -1,8 +1,9 @@
-import { Extension } from '@remirror/core';
+import { Extension, isString } from '@remirror/core';
 import { ExtensionManagerParams, Plugin } from '@remirror/core-types';
 import { isDocNodeEmpty } from '@remirror/core-utils';
 import { cloneElement, getElementProps } from '@remirror/react-utils';
 import { Children } from 'react';
+
 import { EMPTY_NODE_CLASS_NAME } from '../../core-extension-constants';
 import { PlaceholderExtensionOptions, PlaceholderPluginState } from '../../core-extension-types';
 import { createPlaceholderPlugin } from './placeholder-plugin';
@@ -65,7 +66,7 @@ export class PlaceholderExtension extends Extension<PlaceholderExtensionOptions>
       {},
       cloneElement(children, {
         ...props,
-        className: props.className ? `${props.className} ${emptyNodeClass}` : emptyNodeClass,
+        className: isString(props.className) ? `${props.className} ${emptyNodeClass}` : emptyNodeClass,
         'data-placeholder': placeholder,
       }),
     );

--- a/@remirror/core-extensions/src/extensions/placeholder/placeholder-plugin.ts
+++ b/@remirror/core-extensions/src/extensions/placeholder/placeholder-plugin.ts
@@ -3,6 +3,7 @@ import { EditorSchema, Transaction } from '@remirror/core-types';
 import { getPluginState, isDocNodeEmpty } from '@remirror/core-utils';
 import { EditorState, Plugin } from 'prosemirror-state';
 import { Decoration, DecorationSet } from 'prosemirror-view';
+
 import { PlaceholderExtensionOptions, PlaceholderPluginState } from '../../core-extension-types';
 
 /**

--- a/@remirror/core-extensions/src/extensions/position-tracker-extension.ts
+++ b/@remirror/core-extensions/src/extensions/position-tracker-extension.ts
@@ -1,5 +1,5 @@
 import { Extension } from '@remirror/core';
-import { isNumber, isString } from '@remirror/core-helpers';
+import { isNullOrUndefined, isNumber, isString } from '@remirror/core-helpers';
 import {
   BaseExtensionOptions,
   CommandFunction,
@@ -184,7 +184,7 @@ export class PositionTrackerExtension extends Extension<PositionTrackerExtension
           // Get tracker updates from the meta data
           const tracker = getPluginMeta<PositionTrackerExtensionMeta>(key, tr);
 
-          if (!tracker) {
+          if (isNullOrUndefined(tracker)) {
             return decorationSet;
           }
 

--- a/@remirror/core-extensions/src/extensions/ssr-helpers/ssr-helpers-extension.ts
+++ b/@remirror/core-extensions/src/extensions/ssr-helpers/ssr-helpers-extension.ts
@@ -1,5 +1,6 @@
 import { Extension } from '@remirror/core';
 import { BaseExtensionOptions, ExtensionManagerParams } from '@remirror/core-types';
+
 import { DEFAULT_TRANSFORMATIONS, SSRTransformer } from './ssr-helpers-utils';
 
 export interface SSRHelperExtensionOptions extends BaseExtensionOptions {

--- a/@remirror/core-extensions/src/extensions/trailing-node-extension.ts
+++ b/@remirror/core-extensions/src/extensions/trailing-node-extension.ts
@@ -9,6 +9,68 @@ import {
 import { getPluginState, nodeEqualsType } from '@remirror/core-utils';
 import { Plugin } from 'prosemirror-state';
 
+interface CreateTrailingNodePluginParams
+  extends ExtensionTagParams,
+    ExtensionParams<TrailingNodeExtension>,
+    SchemaParams {}
+
+/**
+ * Create the paragraph plugin which can check the end of the document and
+ * insert a new node.
+ */
+export const createTrailingNodePlugin = ({ extension, tags, schema }: CreateTrailingNodePluginParams) => {
+  const { options, pluginKey } = extension;
+  const { disableTags, ignoredNodes, nodeName } = options;
+
+  // The names of the nodes for whom this rule should not be applied.
+  const notAfter: string[] = disableTags
+    ? uniqueArray([...ignoredNodes, nodeName])
+    : uniqueArray([...ignoredNodes, ...tags.general.lastNodeCompatible, nodeName]);
+
+  // The node that will be inserted when the criteria match.
+  const type = schema.nodes[nodeName];
+
+  // The list of nodes for this schema that should have content injected after
+  // them.
+  const types = entries(schema.nodes)
+    .map(([, entry]) => entry)
+    .filter(entry => !notAfter.includes(entry.name));
+
+  return new Plugin<ShouldInsertNodeAtEnd>({
+    key: extension.pluginKey,
+    view() {
+      return {
+        update: view => {
+          const { state, dispatch } = view;
+          const { doc } = state;
+          const shouldInsertNodeAtEnd = getPluginState<ShouldInsertNodeAtEnd>(pluginKey, state);
+          const endPosition = doc.content.size;
+
+          if (!shouldInsertNodeAtEnd) {
+            return;
+          }
+
+          dispatch(state.tr.insert(endPosition, type.create()));
+        },
+      };
+    },
+    state: {
+      init: (_, state) => {
+        const node = state.tr.doc.lastChild;
+        return nodeEqualsType({ node, types });
+      },
+      apply: (tr, state) => {
+        if (!tr.docChanged) {
+          return state;
+        }
+
+        const node = tr.doc.lastChild;
+        return nodeEqualsType({ node, types });
+      },
+    },
+  });
+};
+
 export interface TrailingNodeExtensionOptions extends BaseExtensionOptions {
   /**
    * The node to create at the end of the document.
@@ -72,65 +134,3 @@ export class TrailingNodeExtension extends Extension<TrailingNodeExtensionOption
     return createTrailingNodePlugin({ extension: this, tags, schema });
   }
 }
-
-interface CreateTrailingNodePluginParams
-  extends ExtensionTagParams,
-    ExtensionParams<TrailingNodeExtension>,
-    SchemaParams {}
-
-/**
- * Create the paragraph plugin which can check the end of the document and
- * insert a new node.
- */
-export const createTrailingNodePlugin = ({ extension, tags, schema }: CreateTrailingNodePluginParams) => {
-  const { options, pluginKey } = extension;
-  const { disableTags, ignoredNodes, nodeName } = options;
-
-  // The names of the nodes for whom this rule should not be applied.
-  const notAfter: string[] = disableTags
-    ? uniqueArray([...ignoredNodes, nodeName])
-    : uniqueArray([...ignoredNodes, ...tags.general.lastNodeCompatible, nodeName]);
-
-  // The node that will be inserted when the criteria match.
-  const type = schema.nodes[nodeName];
-
-  // The list of nodes for this schema that should have content injected after
-  // them.
-  const types = entries(schema.nodes)
-    .map(([, entry]) => entry)
-    .filter(entry => !notAfter.includes(entry.name));
-
-  return new Plugin<ShouldInsertNodeAtEnd>({
-    key: extension.pluginKey,
-    view() {
-      return {
-        update: view => {
-          const { state, dispatch } = view;
-          const { doc } = state;
-          const shouldInsertNodeAtEnd = getPluginState<ShouldInsertNodeAtEnd>(pluginKey, state);
-          const endPosition = doc.content.size;
-
-          if (!shouldInsertNodeAtEnd) {
-            return;
-          }
-
-          dispatch(state.tr.insert(endPosition, type.create()));
-        },
-      };
-    },
-    state: {
-      init: (_, state) => {
-        const node = state.tr.doc.lastChild;
-        return nodeEqualsType({ node, types });
-      },
-      apply: (tr, state) => {
-        if (!tr.docChanged) {
-          return state;
-        }
-
-        const node = tr.doc.lastChild;
-        return nodeEqualsType({ node, types });
-      },
-    },
-  });
-};

--- a/@remirror/core-extensions/src/marks/__tests__/link-extension.spec.ts
+++ b/@remirror/core-extensions/src/marks/__tests__/link-extension.spec.ts
@@ -2,6 +2,7 @@ import { fromHTML, toHTML } from '@remirror/core';
 import { createBaseTestManager } from '@remirror/test-fixtures';
 import { pmBuild } from 'jest-prosemirror';
 import { renderEditor } from 'jest-remirror';
+
 import { LinkExtension, LinkExtensionOptions } from '../link-extension';
 
 const href = 'https://test.com';

--- a/@remirror/core-extensions/src/nodes/__tests__/heading-extension.spec.ts
+++ b/@remirror/core-extensions/src/nodes/__tests__/heading-extension.spec.ts
@@ -2,6 +2,7 @@ import { fromHTML, toHTML } from '@remirror/core';
 import { createBaseTestManager } from '@remirror/test-fixtures';
 import { pmBuild } from 'jest-prosemirror';
 import { renderEditor } from 'jest-remirror';
+
 import { BoldExtension } from '../../marks';
 import { HeadingExtension, HeadingExtensionOptions } from '../heading-extension';
 

--- a/@remirror/core-extensions/src/nodes/heading-extension.ts
+++ b/@remirror/core-extensions/src/nodes/heading-extension.ts
@@ -61,7 +61,7 @@ export class HeadingExtension extends NodeExtension<HeadingExtensionOptions> {
           return [`h${this.options.defaultLevel}`, 0];
         }
 
-        return [`h${node.attrs.level}`, 0];
+        return [`h${node.attrs.level as string}`, 0];
       },
     };
   }

--- a/@remirror/core-extensions/src/nodes/node-constants.ts
+++ b/@remirror/core-extensions/src/nodes/node-constants.ts
@@ -48,7 +48,7 @@ export const ALIGN_PATTERN = /(left|right|center|justify)/;
 /**
  * Regex for matching sizes in the DOM.
  */
-export const SIZE_PATTERN = /([\d\.]+)(px|pt)/i;
+export const SIZE_PATTERN = /([\d.]+)(px|pt)/i;
 
 /**
  * The default pixel to pt font size ratio.
@@ -67,4 +67,4 @@ export const PT_TO_PIXEL_RATIO = 1.33;
  */
 export const FONT_PT_SIZES = [8, 9, 10, 11, 12, 14, 18, 24, 30, 36, 48, 60, 72, 90];
 
-export const CSS_ROTATE_PATTERN = /rotate\(([0-9\.]+)rad\)/i;
+export const CSS_ROTATE_PATTERN = /rotate\(([0-9.]+)rad\)/i;

--- a/@remirror/core-extensions/src/nodes/node-utils.ts
+++ b/@remirror/core-extensions/src/nodes/node-utils.ts
@@ -1,4 +1,5 @@
 import { clamp } from '@remirror/core';
+
 import { INDENT_LEVELS, INDENT_MARGIN_PT_SIZE, PIXEL_TO_PT_RATIO, SIZE_PATTERN } from './node-constants';
 import { IndentLevels } from './paragraph/paragraph-types';
 

--- a/@remirror/core-extensions/src/nodes/ordered-list-extension.ts
+++ b/@remirror/core-extensions/src/nodes/ordered-list-extension.ts
@@ -1,7 +1,7 @@
 import {
-  Cast,
   CommandNodeTypeParams,
   ExtensionManagerNodeTypeParams,
+  isElementDOMNode,
   NodeExtension,
   NodeExtensionSpec,
   NodeGroup,
@@ -27,11 +27,15 @@ export class OrderedListExtension extends NodeExtension {
       parseDOM: [
         {
           tag: 'ol',
-          getAttrs: node => ({
-            order: Cast<Element>(node).hasAttribute('start')
-              ? +Cast<Element>(node).getAttribute('start')!
-              : 1,
-          }),
+          getAttrs: node => {
+            if (!isElementDOMNode(node)) {
+              return {};
+            }
+
+            return {
+              order: +(node.getAttribute('start') ?? 1),
+            };
+          },
         },
       ],
       toDOM: node => (node.attrs.order === 1 ? ['ol', 0] : ['ol', { start: node.attrs.order }, 0]),
@@ -54,7 +58,7 @@ export class OrderedListExtension extends NodeExtension {
         /^(\d+)\.\s$/,
         type,
         match => ({ order: +match[1] }),
-        (match, node) => node.childCount + node.attrs.order === +match[1],
+        (match, node) => node.childCount + (node.attrs.order as number) === +match[1],
       ),
     ];
   }

--- a/@remirror/core-extensions/src/nodes/paragraph/__tests__/paragraph-extension.spec.ts
+++ b/@remirror/core-extensions/src/nodes/paragraph/__tests__/paragraph-extension.spec.ts
@@ -1,6 +1,7 @@
 import { fromHTML, toHTML } from '@remirror/core';
 import { createBaseTestManager } from '@remirror/test-fixtures';
 import { pmBuild } from 'jest-prosemirror';
+
 import { ParagraphExtension } from '../paragraph-extension';
 
 describe('schema', () => {

--- a/@remirror/core-extensions/src/nodes/paragraph/paragraph-extension.ts
+++ b/@remirror/core-extensions/src/nodes/paragraph/paragraph-extension.ts
@@ -1,8 +1,34 @@
 import { CommandNodeTypeParams, NodeExtension, NodeExtensionSpec, NodeGroup, Tags } from '@remirror/core';
 import { setBlockType } from 'prosemirror-commands';
+
 import { ALIGN_PATTERN, INDENT_ATTRIBUTE, INDENT_LEVELS } from '../node-constants';
 import { marginToIndent } from '../node-utils';
 import { ParagraphExtensionAttrs, ParagraphExtensionOptions } from './paragraph-types';
+
+/**
+ * Pull the paragraph attributes from the dom element.
+ */
+const getAttrs = (
+  { indentAttribute, indentLevels }: Required<ParagraphExtensionOptions>,
+  dom: HTMLElement,
+) => {
+  const { lineHeight, textAlign, marginLeft } = dom.style;
+  let align: string | undefined = dom.getAttribute('align') ?? (textAlign || '');
+  let indent = parseInt(dom.getAttribute(indentAttribute) ?? '0', 10);
+
+  align = ALIGN_PATTERN.test(align) ? align : undefined;
+
+  if (!indent && marginLeft) {
+    indent = marginToIndent(marginLeft);
+  }
+
+  indent = indent || indentLevels[0];
+
+  const lineSpacing = lineHeight ? lineHeight : undefined;
+  const id = dom.getAttribute('id') ?? undefined;
+
+  return { align, indent, lineSpacing, id } as ParagraphExtensionAttrs;
+};
 
 /**
  * The paragraph is one of the essential building blocks for a prosemirror
@@ -88,28 +114,3 @@ export class ParagraphExtension extends NodeExtension<ParagraphExtensionOptions>
     };
   }
 }
-
-/**
- * Pull the paragraph attributes from the dom element.
- */
-const getAttrs = (
-  { indentAttribute, indentLevels }: Required<ParagraphExtensionOptions>,
-  dom: HTMLElement,
-) => {
-  const { lineHeight, textAlign, marginLeft } = dom.style;
-  let align: string | undefined = dom.getAttribute('align') ?? (textAlign || '');
-  let indent = parseInt(dom.getAttribute(indentAttribute) ?? '0', 10);
-
-  align = ALIGN_PATTERN.test(align) ? align : undefined;
-
-  if (!indent && marginLeft) {
-    indent = marginToIndent(marginLeft);
-  }
-
-  indent = indent || indentLevels[0];
-
-  const lineSpacing = lineHeight ? lineHeight : undefined;
-  const id = dom.getAttribute('id') ?? undefined;
-
-  return { align, indent, lineSpacing, id } as ParagraphExtensionAttrs;
-};

--- a/@remirror/core-helpers/src/__tests__/core-helper.spec.ts
+++ b/@remirror/core-helpers/src/__tests__/core-helper.spec.ts
@@ -6,6 +6,7 @@ import {
   findMatches,
   format,
   get,
+  hasOwnProperty,
   isBoolean,
   isDate,
   isEmptyArray,
@@ -40,7 +41,6 @@ import {
   uniqueBy,
   uniqueId,
   within,
-  hasOwnProperty,
 } from '../core-helpers';
 
 describe('findMatches', () => {

--- a/@remirror/core-helpers/src/core-helpers.ts
+++ b/@remirror/core-helpers/src/core-helpers.ts
@@ -501,8 +501,8 @@ export const randomInt = (min: number, max?: number) => Math.floor(randomFloat(m
 export const startCase = (str: string) => {
   return str
     .replace(/_/g, ' ')
-    .replace(/([a-z])([A-Z])/g, (_, $1, $2) => `${$1} ${$2}`)
-    .replace(/(\s|^)(\w)/g, (_, $1, $2) => `${$1}${$2.toUpperCase()}`);
+    .replace(/([a-z])([A-Z])/g, (_, $1: string, $2: string) => `${$1} ${$2}`)
+    .replace(/(\s|^)(\w)/g, (_, $1: string, $2: string) => `${$1}${$2.toUpperCase()}`);
 };
 
 const wordSeparators = /[\s\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-./:;<=>?@[\]^_`{|}~]+/;

--- a/@remirror/core-types/src/core-types.ts
+++ b/@remirror/core-types/src/core-types.ts
@@ -3,6 +3,7 @@ import { PortalContainer } from '@remirror/react-portals';
 import { MarkSpec, MarkType, NodeSpec, NodeType } from 'prosemirror-model';
 import { Decoration } from 'prosemirror-view';
 import { ComponentType } from 'react';
+
 import {
   EditorSchema,
   EditorState,

--- a/@remirror/core-types/src/ui-types.ts
+++ b/@remirror/core-types/src/ui-types.ts
@@ -16,6 +16,7 @@ import {
   WidthProperty,
   ZIndexProperty,
 } from 'csstype';
+
 import { StringKey } from './base-types';
 
 export type RemirrorThemeColorMode = {

--- a/@remirror/core-utils/src/__tests__/command-utils.spec.ts
+++ b/@remirror/core-utils/src/__tests__/command-utils.spec.ts
@@ -1,4 +1,5 @@
 import { atomInline, blockquote, doc, h1, li, p, schema, strong, ul } from 'jest-prosemirror';
+
 import {
   removeMark,
   replaceText,

--- a/@remirror/core-utils/src/__tests__/dom-utils.spec.ts
+++ b/@remirror/core-utils/src/__tests__/dom-utils.spec.ts
@@ -1,5 +1,6 @@
 import { NodeMatch } from '@remirror/core-types';
 import { docNodeBasicJSON } from '@remirror/test-fixtures';
+import domino from 'domino';
 import {
   atomInline,
   blockquote,
@@ -14,6 +15,7 @@ import {
   tableRow,
 } from 'jest-prosemirror';
 import { TextSelection } from 'prosemirror-state';
+
 import {
   atDocEnd,
   atDocStart,
@@ -41,8 +43,6 @@ import {
   toDOM,
   toHTML,
 } from '../dom-utils';
-
-import domino from 'domino';
 
 describe('markActive', () => {
   it('shows active when within an active region', () => {

--- a/@remirror/core-utils/src/__tests__/prosemirror-node-utils.spec.ts
+++ b/@remirror/core-utils/src/__tests__/prosemirror-node-utils.spec.ts
@@ -1,5 +1,6 @@
 import { bool } from '@remirror/core-helpers';
 import { atomInline, createEditor, doc, p, strong, table, td, tdEmpty, tr as row } from 'jest-prosemirror';
+
 import {
   contains,
   findBlockNodes,

--- a/@remirror/core-utils/src/__tests__/prosemirror-rules.spec.ts
+++ b/@remirror/core-utils/src/__tests__/prosemirror-rules.spec.ts
@@ -1,4 +1,5 @@
 import { createEditor, doc, horizontalRule, p, schema as testSchema, strong } from 'jest-prosemirror';
+
 import { markInputRule, markPasteRule, nodeInputRule, plainInputRule } from '../prosemirror-rules';
 
 describe('markPasteRule', () => {

--- a/@remirror/core-utils/src/__tests__/prosemirror-utils.spec.ts
+++ b/@remirror/core-utils/src/__tests__/prosemirror-utils.spec.ts
@@ -15,14 +15,14 @@ import {
   tdEmpty,
   tr as row,
 } from 'jest-prosemirror';
+import { Schema } from 'prosemirror-model';
 import { marks, nodes } from 'prosemirror-schema-basic';
 import { NodeSelection, Selection, TextSelection } from 'prosemirror-state';
+
 import {
   cloneTransaction,
   findElementAtPosition,
-  findNodeAtEndOfDoc,
   findNodeAtSelection,
-  findNodeAtStartOfDoc,
   findParentNode,
   findParentNodeOfType,
   findPositionOfNodeBefore,
@@ -31,11 +31,10 @@ import {
   nodeEqualsType,
   removeNodeAtPosition,
   removeNodeBefore,
+  schemaToJSON,
   selectionEmpty,
   transactionChanged,
-  schemaToJSON,
 } from '../prosemirror-utils';
-import { Schema } from 'prosemirror-model';
 
 describe('nodeEqualsType', () => {
   it('matches with a singular nodeType', () => {
@@ -410,16 +409,6 @@ describe('findNodeAt...', () => {
     expect(node).toBe(expectedEnd);
     expect(pos).toBe(16);
     expect(start).toBe(17);
-  });
-
-  test('findNodeAtEndOfDoc', () => {
-    const { node } = findNodeAtEndOfDoc(pmDoc);
-    expect(node).toBe(expectedEnd);
-  });
-
-  test('findNodeAtStartOfDoc', () => {
-    const { node } = findNodeAtStartOfDoc(pmDoc);
-    expect(node).toBe(expectedStart);
   });
 });
 

--- a/@remirror/core-utils/src/command-utils.ts
+++ b/@remirror/core-utils/src/command-utils.ts
@@ -13,6 +13,7 @@ import {
 } from '@remirror/core-types';
 import { lift, setBlockType, wrapIn } from 'prosemirror-commands';
 import { liftListItem, wrapInList } from 'prosemirror-schema-list';
+
 import { getMarkRange, isMarkType, isNodeType } from './dom-utils';
 import { isNodeActive, selectionEmpty } from './prosemirror-utils';
 
@@ -164,6 +165,17 @@ const callMethod = <
 ): GReturn => (isFunction(fn) ? fn(...args) : defaultReturn);
 
 /**
+ * Taken from https://stackoverflow.com/a/4900484
+ *
+ * Check that the browser is chrome. Supports passing a minimum version to check that it is a greater than or equal version.
+ */
+const isChrome = (minVersion = 0): boolean => {
+  const parsedAgent = navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./);
+
+  return parsedAgent ? parseInt(parsedAgent[2], 10) >= minVersion : false;
+};
+
+/**
  * Replaces text with an optional appended string at the end
  *
  * @param params - the destructured params
@@ -209,7 +221,7 @@ export const replaceText = ({
     if (isChrome(60)) {
       // A workaround for a chrome bug
       // https://github.com/ProseMirror/prosemirror/issues/710#issuecomment-338047650
-      document.getSelection()!.empty();
+      document.getSelection()?.empty();
     }
     dispatch(callMethod({ fn: endTransaction, defaultReturn: tr }, [tr, state]));
   }
@@ -260,15 +272,4 @@ export const removeMark = ({
   }
 
   return true;
-};
-
-/**
- * Taken from https://stackoverflow.com/a/4900484
- *
- * Check that the browser is chrome. Supports passing a minimum version to check that it is a greater than or equal version.
- */
-const isChrome = (minVersion = 0): boolean => {
-  const parsedAgent = navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./);
-
-  return parsedAgent ? parseInt(parsedAgent[2], 10) >= minVersion : false;
 };

--- a/@remirror/core-utils/src/dom-utils.ts
+++ b/@remirror/core-utils/src/dom-utils.ts
@@ -1,5 +1,13 @@
 import { EMPTY_PARAGRAPH_NODE } from '@remirror/core-constants';
-import { bool, Cast, isFunction, isNumber, isObject, isString } from '@remirror/core-helpers';
+import {
+  bool,
+  Cast,
+  isFunction,
+  isNullOrUndefined,
+  isNumber,
+  isObject,
+  isString,
+} from '@remirror/core-helpers';
 import {
   EditorSchema,
   EditorState,
@@ -14,6 +22,7 @@ import {
   PluginKey,
   PositionParams,
   ProsemirrorNode,
+  ProsemirrorNodeParams,
   RegexTuple,
   RemirrorContentType,
   RenderEnvironment,
@@ -21,7 +30,6 @@ import {
   SchemaParams,
   Selection,
   Transaction,
-  ProsemirrorNodeParams,
 } from '@remirror/core-types';
 import minDocument from 'min-document';
 import {
@@ -33,8 +41,8 @@ import {
   Node as PMNode,
   NodeType,
   ResolvedPos as PMResolvedPos,
-  Slice,
   Schema,
+  Slice,
 } from 'prosemirror-model';
 import {
   EditorState as PMEditorState,
@@ -43,6 +51,7 @@ import {
   Selection as PMSelection,
   TextSelection,
 } from 'prosemirror-state';
+
 import { environment } from './environment';
 
 /**
@@ -220,7 +229,7 @@ export const isDocNodeEmpty = (node: ProsemirrorNode) => {
     nodeChild.type.isBlock &&
     !nodeChild.childCount &&
     nodeChild.nodeSize === 2 &&
-    (!nodeChild.marks || nodeChild.marks.length === 0)
+    (isNullOrUndefined(nodeChild.marks) || nodeChild.marks.length === 0)
   );
 };
 
@@ -468,13 +477,13 @@ export const closestElement = (domNode: Node | null | undefined, selector: strin
   if (!isElementDOMNode(domNode)) {
     return null;
   }
-  if (!document.documentElement || !document.documentElement.contains(domNode)) {
+  if (isNullOrUndefined(document.documentElement) || !document.documentElement.contains(domNode)) {
     return null;
   }
-  const matches = domNode.matches ? 'matches' : Cast<'matches'>('msMatchesSelector');
+  const matches = isFunction(domNode.matches) ? 'matches' : Cast<'matches'>('msMatchesSelector');
 
   do {
-    if (domNode[matches] && domNode[matches](selector)) {
+    if (isFunction(domNode[matches]) && domNode[matches](selector)) {
       return domNode;
     }
     domNode = (domNode.parentElement ?? domNode.parentNode) as HTMLElement;
@@ -496,7 +505,9 @@ export const isTextDOMNode = (domNode: unknown): domNode is Text => {
 interface GetOffsetParentParams extends EditorViewParams, ElementParams {}
 
 export const getOffsetParent = ({ view, element }: GetOffsetParentParams): HTMLElement =>
-  element ? (element.offsetParent as HTMLElement) : ((view.dom as HTMLElement).offsetParent as HTMLElement);
+  isNullOrUndefined(element)
+    ? ((view.dom as HTMLElement).offsetParent as HTMLElement)
+    : (element.offsetParent as HTMLElement);
 
 /**
  * Retrieve the line height from a an element

--- a/@remirror/core-utils/src/prosemirror-node-utils.ts
+++ b/@remirror/core-utils/src/prosemirror-node-utils.ts
@@ -1,4 +1,4 @@
-import { bool } from '@remirror/core-helpers';
+import { bool, isFunction } from '@remirror/core-helpers';
 import {
   Attrs,
   MarkTypeParams,
@@ -9,6 +9,7 @@ import {
   ProsemirrorNode,
   ProsemirrorNodeParams,
 } from '@remirror/core-types';
+
 import { isProsemirrorNode } from './dom-utils';
 
 interface DescendParams {
@@ -71,7 +72,7 @@ interface FindChildrenParams extends FlattenParams, NodePredicateParams {}
 export const findChildren = ({ node, predicate, descend }: FindChildrenParams) => {
   if (!node) {
     throw new Error('Invalid "node" parameter');
-  } else if (!predicate) {
+  } else if (!isFunction(predicate)) {
     throw new Error('Invalid "predicate" parameter');
   }
   return flatten({ node, descend }).filter(child => predicate(child.node));

--- a/@remirror/core/src/__tests__/extension-manager.helpers.spec.ts
+++ b/@remirror/core/src/__tests__/extension-manager.helpers.spec.ts
@@ -1,4 +1,5 @@
 import { TestExtension } from '@remirror/test-fixtures';
+
 import { transformExtensionMap } from '../extension-manager.helpers';
 import { DocExtension, TextExtension } from '../nodes';
 

--- a/@remirror/core/src/__tests__/extension-manager.spec.tsx
+++ b/@remirror/core/src/__tests__/extension-manager.spec.tsx
@@ -2,10 +2,11 @@ import { EMPTY_PARAGRAPH_NODE, Tags } from '@remirror/core-constants';
 import { Cast } from '@remirror/core-helpers';
 import { Attrs, EditorState, NodeExtensionSpec } from '@remirror/core-types';
 import { PortalContainer } from '@remirror/react-portals';
-import { defaultRemirrorThemeValue } from '@remirror/ui';
 import { createTestManager, extensions } from '@remirror/test-fixtures';
+import { defaultRemirrorThemeValue } from '@remirror/ui';
 import { EditorView } from 'prosemirror-view';
 import React, { FC } from 'react';
+
 import { Extension } from '../extension';
 import { ExtensionManager, isExtensionManager } from '../extension-manager';
 import { NodeExtension } from '../node-extension';

--- a/@remirror/core/src/__tests__/node-extension.spec.ts
+++ b/@remirror/core/src/__tests__/node-extension.spec.ts
@@ -3,6 +3,7 @@ import { NodeExtensionSpec } from '@remirror/core-types';
 import { fromHTML } from '@remirror/core-utils';
 import { createBaseTestManager } from '@remirror/test-fixtures';
 import { pmBuild } from 'jest-prosemirror';
+
 import { NodeExtension } from '../';
 
 class CustomExtension extends NodeExtension {

--- a/@remirror/core/src/extension-helpers.ts
+++ b/@remirror/core/src/extension-helpers.ts
@@ -1,5 +1,6 @@
-import { ExtensionType, DEFAULT_EXTENSION_PRIORITY, RemirrorClassName } from '@remirror/core-constants';
+import { DEFAULT_EXTENSION_PRIORITY, ExtensionType, RemirrorClassName } from '@remirror/core-constants';
 import { isObject } from '@remirror/core-helpers';
+
 import { Extension } from './extension';
 import { AnyExtension, FlexibleExtension, PrioritizedExtension } from './extension-types';
 import { MarkExtension } from './mark-extension';
@@ -11,7 +12,7 @@ import { NodeExtension } from './node-extension';
  * @param extension - the extension to check
  */
 export const isExtension = (extension: unknown): extension is AnyExtension =>
-  isObject(extension) && extension.toString() == RemirrorClassName.Extension;
+  isObject(extension) && extension.toString() === RemirrorClassName.Extension;
 
 // export const isExtension = _isObjectOfType<AnyExtension>(_TypeName.RemirrorExtension);
 

--- a/@remirror/core/src/extension-manager.helpers.ts
+++ b/@remirror/core/src/extension-manager.helpers.ts
@@ -1,5 +1,5 @@
 import { MarkGroup, NodeGroup, Tags } from '@remirror/core-constants';
-import { bool, Cast, entries, isFunction, sort } from '@remirror/core-helpers';
+import { bool, Cast, entries, isFunction, isUndefined, sort } from '@remirror/core-helpers';
 import {
   AnyFunction,
   CommandParams,
@@ -11,7 +11,8 @@ import {
   MarkExtensionTags,
   NodeExtensionTags,
 } from '@remirror/core-types';
-import { isMarkExtension, isNodeExtension, convertToPrioritizedExtension } from './extension-helpers';
+
+import { convertToPrioritizedExtension, isMarkExtension, isNodeExtension } from './extension-helpers';
 import {
   AnyExtension,
   ExtensionListParams,
@@ -315,14 +316,20 @@ export const createExtensionTags = <
   for (const extension of extensions) {
     if (isNodeExtension(extension)) {
       const group = extension.schema.group as NodeGroup;
-      node[group] = node[group] ? [...node[group], extension.name as GNodes] : [extension.name as GNodes];
+      node[group] = isUndefined(node[group])
+        ? [extension.name as GNodes]
+        : [...node[group], extension.name as GNodes];
     } else if (isMarkExtension(extension)) {
       const group = extension.schema.group as MarkGroup;
-      mark[group] = mark[group] ? [...mark[group], extension.name as GMarks] : [extension.name as GMarks];
+      mark[group] = isUndefined(mark[group])
+        ? [extension.name as GMarks]
+        : [...mark[group], extension.name as GMarks];
     }
 
     (extension.tags as Tags[]).forEach(tag => {
-      general[tag] = general[tag] ? [...general[tag], extension.name as GNames] : [extension.name as GNames];
+      general[tag] = isUndefined(general[tag])
+        ? [extension.name as GNames]
+        : [...general[tag], extension.name as GNames];
     });
   }
 

--- a/@remirror/core/src/extension-manager.ts
+++ b/@remirror/core/src/extension-manager.ts
@@ -1,5 +1,5 @@
 import { Interpolation } from '@emotion/core';
-import { bool, isArray, isEqual, isFunction, isInstanceOf, hasOwnProperty } from '@remirror/core-helpers';
+import { bool, hasOwnProperty, isArray, isEqual, isFunction, isInstanceOf } from '@remirror/core-helpers';
 import {
   ActionMethod,
   AnyActions,
@@ -32,6 +32,7 @@ import { Schema } from 'prosemirror-model';
 import { EditorState } from 'prosemirror-state';
 import { suggest, Suggester } from 'prosemirror-suggest';
 import { ComponentType } from 'react';
+
 import { isMarkExtension, isNodeExtension } from './extension-helpers';
 import {
   createCommands,
@@ -475,6 +476,7 @@ export class ExtensionManager<GExtension extends AnyExtension = any>
   public getPluginState<GState>(name: this['_N']): GState {
     this.checkInitialized();
     const key = this.pluginKeys[name];
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (!key) {
       throw new Error(`Cannot retrieve state for an extension: ${name} which doesn't exist`);
     }
@@ -551,8 +553,10 @@ export class ExtensionManager<GExtension extends AnyExtension = any>
     const commands = createCommands({ extensions, params });
 
     Object.entries(commands).forEach(([commandName, { command, name }]) => {
-      const isActive = this.initData.isActive[name as this['_Names']] || defaultIsActive;
-      const isEnabled = this.initData.isEnabled[name as this['_Names']] || defaultIsEnabled;
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      const isActive = this.initData.isActive[name as this['_Names']] ?? defaultIsActive;
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      const isEnabled = this.initData.isEnabled[name as this['_Names']] ?? defaultIsEnabled;
 
       actions[commandName] = command as ActionMethod;
       actions[commandName].isActive = (attrs?: Attrs) => isActive({ attrs, command: commandName });
@@ -640,7 +644,7 @@ export class ExtensionManager<GExtension extends AnyExtension = any>
       .filter(extension => !extension.options.exclude.keymaps)
       .map(extensionPropertyMapper('keys', this.params));
 
-    const mappedKeys: Record<string, CommandFunction> = Object.create(null);
+    const mappedKeys: Partial<Record<string, CommandFunction>> = Object.create(null);
 
     for (const extensionKeymap of extensionKeymaps) {
       for (const key in extensionKeymap) {

--- a/@remirror/core/src/extension-types.ts
+++ b/@remirror/core/src/extension-types.ts
@@ -8,6 +8,7 @@ import {
   StringKey,
   UnionToIntersection,
 } from '@remirror/core-types';
+
 import { Extension } from './extension';
 import { MarkExtension } from './mark-extension';
 import { NodeExtension } from './node-extension';

--- a/@remirror/core/src/extension.ts
+++ b/@remirror/core/src/extension.ts
@@ -1,5 +1,5 @@
 import { Interpolation } from '@emotion/core';
-import { ExtensionType, Tags, RemirrorClassName } from '@remirror/core-constants';
+import { ExtensionType, RemirrorClassName, Tags } from '@remirror/core-constants';
 import { deepMerge, isString } from '@remirror/core-helpers';
 import {
   AnyFunction,
@@ -12,12 +12,12 @@ import {
   ExtensionHelperReturn,
   ExtensionManagerParams,
   ExtensionManagerTypeParams,
+  ExtraAttrs,
   KeyboardBindings,
   NodeViewMethod,
   OnTransactionParams,
   PlainObject,
   ProsemirrorPlugin,
-  ExtraAttrs,
 } from '@remirror/core-types';
 import { InputRule } from 'prosemirror-inputrules';
 import { PluginKey } from 'prosemirror-state';

--- a/@remirror/core/src/mark-extension.ts
+++ b/@remirror/core/src/mark-extension.ts
@@ -8,6 +8,7 @@ import {
   MarkType,
 } from '@remirror/core-types';
 import { isMarkActive } from '@remirror/core-utils';
+
 import { Extension } from './extension';
 
 /**

--- a/@remirror/core/src/node-extension.ts
+++ b/@remirror/core/src/node-extension.ts
@@ -8,6 +8,7 @@ import {
   NodeType,
 } from '@remirror/core-types';
 import { isNodeActive } from '@remirror/core-utils';
+
 import { Extension } from './extension';
 
 /**

--- a/@remirror/core/src/nodes/__tests__/nodes.spec.ts
+++ b/@remirror/core/src/nodes/__tests__/nodes.spec.ts
@@ -1,4 +1,5 @@
 import { Cast } from '@remirror/core-helpers';
+
 import { DocExtension, TextExtension } from '../..';
 
 // While these tests seem simple there is a reason for them.

--- a/@remirror/core/src/nodes/doc-extension.ts
+++ b/@remirror/core/src/nodes/doc-extension.ts
@@ -1,4 +1,5 @@
 import { NodeExtensionOptions, NodeExtensionSpec } from '@remirror/core-types';
+
 import { NodeExtension } from '../node-extension';
 
 export interface DocExtensionOptions extends NodeExtensionOptions {

--- a/@remirror/dev/src/__tests__/prosemirror-dev-tools.spec.tsx
+++ b/@remirror/dev/src/__tests__/prosemirror-dev-tools.spec.tsx
@@ -1,6 +1,7 @@
 import { ManagedRemirrorProvider, RemirrorManager } from '@remirror/react';
 import { render } from '@testing-library/react';
 import React from 'react';
+
 import { ProsemirrorDevTools } from '../dev-components';
 
 beforeEach(() => {

--- a/@remirror/dev/src/dev-components.ts
+++ b/@remirror/dev/src/dev-components.ts
@@ -25,9 +25,7 @@ export const ProsemirrorDevTools = () => {
         return;
       }
 
-      if (node) {
-        unmountComponentAtNode(node);
-      }
+      unmountComponentAtNode(node);
 
       if (node.parentNode) {
         node.parentNode.removeChild(node);

--- a/@remirror/editor-markdown/src/from-markdown.ts
+++ b/@remirror/editor-markdown/src/from-markdown.ts
@@ -24,7 +24,7 @@ export const fromMarkdown = (markdown: string, schema: EditorSchema) =>
       getAttrs: tok => ({
         src: tok.attrGet('src'),
         title: tok.attrGet('title') ?? null,
-        alt: (tok.children[0] && tok.children[0].content) || null,
+        alt: tok.children[0]?.content || null,
       }),
     },
     hardbreak: { node: 'hardBreak' },

--- a/@remirror/editor-markdown/src/markdown-editor.tsx
+++ b/@remirror/editor-markdown/src/markdown-editor.tsx
@@ -40,13 +40,13 @@ import { CodeBlockExtension } from '@remirror/extension-code-block';
 import { ImageExtension } from '@remirror/extension-image';
 import { RemirrorProvider, RemirrorProviderProps, RemirrorStateListenerParams } from '@remirror/react';
 import { FC, Fragment, useCallback, useEffect, useMemo, useState } from 'react';
-import { fromMarkdown } from './from-markdown';
-import { toMarkdown } from './to-markdown';
-
 import bash from 'refractor/lang/bash';
 import markdown from 'refractor/lang/markdown';
 import tsx from 'refractor/lang/tsx';
 import typescript from 'refractor/lang/typescript';
+
+import { fromMarkdown } from './from-markdown';
+import { toMarkdown } from './to-markdown';
 
 /**
  * The props which are passed to the internal RemirrorProvider
@@ -193,13 +193,14 @@ const useDebounce = (fn: () => any, ms: number = 0, args: any[] = []) => {
 };
 
 export const MarkdownEditor: FC<MarkdownEditorProps> = ({ initialValue = '', editor, children }) => {
+  const wysiwygManager = useWysiwygManager();
+  const markdownManager = useMarkdownManager();
+
   type WysiwygExtensions = ExtensionsFromManager<typeof wysiwygManager>;
   type WysiwygSchema = SchemaFromExtensions<WysiwygExtensions>;
   type MarkdownExtensions = ExtensionsFromManager<typeof markdownManager>;
   type MarkdownSchema = SchemaFromExtensions<MarkdownExtensions>;
 
-  const wysiwygManager = useWysiwygManager();
-  const markdownManager = useMarkdownManager();
   const initialContent = createInitialContent({ content: initialValue, schema: wysiwygManager.schema });
   const [markdownEditorState, setMarkdownEditorState] = useState<EditorState<MarkdownSchema>>();
   const [markdownParams, setMarkdownParams] = useState<

--- a/@remirror/editor-social/src/__tests__/social-ssr.spec.tsx
+++ b/@remirror/editor-social/src/__tests__/social-ssr.spec.tsx
@@ -5,11 +5,11 @@
 /** @jsx jsx */
 
 import { jsx } from '@emotion/core';
+import { noop } from '@remirror/core';
+import { docNodeBasicJSON } from '@remirror/test-fixtures';
 import { renderToString } from 'react-dom/server';
 
-import { docNodeBasicJSON } from '@remirror/test-fixtures';
 import { SocialEditor } from '..';
-import { noop } from '@remirror/core';
 
 test('it renders within an ssr environment', () => {
   // global.renderToString = renderToString;

--- a/@remirror/editor-social/src/__tests__/social.spec.tsx
+++ b/@remirror/editor-social/src/__tests__/social.spec.tsx
@@ -1,7 +1,7 @@
+import { docNodeBasicJSON } from '@remirror/test-fixtures';
 import { render } from '@testing-library/react';
 import React from 'react';
 
-import { docNodeBasicJSON } from '@remirror/test-fixtures';
 import { SocialEditor } from '..';
 
 test('should place the editor within the correct element', () => {

--- a/@remirror/editor-social/src/components/emoji-suggestion-component.tsx
+++ b/@remirror/editor-social/src/components/emoji-suggestion-component.tsx
@@ -5,6 +5,7 @@ import { popupMenuPositioner, useRemirrorContext } from '@remirror/react';
 import { useRemirrorTheme } from '@remirror/ui';
 import { Type, useMultishift } from 'multishift';
 import { FunctionComponent } from 'react';
+
 import { DataParams, SocialExtensions } from '../social-types';
 
 interface EmojiSuggestionsProps extends DataParams<EmojiObject> {
@@ -28,10 +29,15 @@ export const EmojiSuggestions: FunctionComponent<EmojiSuggestionsProps> = ({
     items: data,
     isOpen: true,
   });
-  const { top, left, ref } = getPositionerProps({
+
+  const positionerProps = getPositionerProps({
     ...popupMenuPositioner,
     positionerId: 'emojiPopupMenu',
+    refKey: 'ref',
   });
+
+  const { top, left, ref } = positionerProps;
+
   return (
     <div
       {...getMenuProps({ ref })}

--- a/@remirror/editor-social/src/components/social-base-components.tsx
+++ b/@remirror/editor-social/src/components/social-base-components.tsx
@@ -2,6 +2,7 @@
 import { jsx } from '@emotion/core';
 import { useRemirrorTheme } from '@remirror/ui';
 import { forwardRef } from 'react';
+
 import { DivProps } from '../social-types';
 
 export const CharacterCountWrapper = forwardRef<HTMLDivElement, DivProps>((props, ref) => {

--- a/@remirror/editor-social/src/components/social-character-count-component.tsx
+++ b/@remirror/editor-social/src/components/social-character-count-component.tsx
@@ -26,7 +26,7 @@ const CharacterCountIndicatorComponent: FC<CharacterCountIndicatorProps> = ({
   const remainingCharacters = characters.total - characters.used;
   const warn = remainingCharacters <= warningThreshold;
   const ratio = characters.used / characters.total;
-  const strokeColor = remainingCharacters < 0 ? colors.error : warn ? colors.warn : colors.primary!;
+  const strokeColor = remainingCharacters < 0 ? colors.error : warn ? colors.warn : colors.primary;
 
   // SVG centers the stroke width on the radius, subtract out so circle fits in square
   const radius = (size - strokeWidth) / 2;

--- a/@remirror/editor-social/src/components/social-editor.tsx
+++ b/@remirror/editor-social/src/components/social-editor.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 
 import { jsx } from '@emotion/core';
-import { deepMerge, omit, RemirrorTheme } from '@remirror/core';
+import { deepMerge, isUndefined, omit, RemirrorTheme } from '@remirror/core';
 import { NodeCursorExtension, PlaceholderExtension } from '@remirror/core-extensions';
 import {
   EmojiExtension,
@@ -15,12 +15,19 @@ import {
 import { EnhancedLinkExtension } from '@remirror/extension-enhanced-link';
 import {
   MentionExtension,
-  MentionExtensionOptions,
   MentionExtensionMatcher,
+  MentionExtensionOptions,
 } from '@remirror/extension-mention';
 import { ManagedRemirrorProvider, RemirrorExtension, RemirrorManager } from '@remirror/react';
 import { RemirrorThemeProvider } from '@remirror/ui';
+import {
+  SuggestChangeHandlerParams,
+  SuggestKeyBindingMap,
+  SuggestKeyBindingParams,
+  SuggestStateMatch,
+} from 'prosemirror-suggest';
 import { Fragment, PureComponent } from 'react';
+
 import { socialEditorTheme } from '../social-theme';
 import {
   ActiveTagData,
@@ -32,12 +39,6 @@ import {
 } from '../social-types';
 import { calculateNewIndexFromArrowPress, mapToActiveIndex } from '../social-utils';
 import { SocialEditorComponent } from './social-wrapper-component';
-import {
-  SuggestStateMatch,
-  SuggestKeyBindingMap,
-  SuggestKeyBindingParams,
-  SuggestChangeHandlerParams,
-} from 'prosemirror-suggest';
 
 interface State {
   activeMatcher: MatchName | undefined;
@@ -323,10 +324,10 @@ export class SocialEditor extends PureComponent<SocialEditorProps, State> {
         return false;
       }
 
-      const emoji = emojiList[activeEmojiIndex];
+      const emoji: EmojiObject | undefined = emojiList[activeEmojiIndex];
 
       // Check if a matching id exists because the user has selected something.
-      if (!emoji) {
+      if (isUndefined(emoji)) {
         return false;
       }
 

--- a/@remirror/editor-social/src/components/social-suggestion-components.tsx
+++ b/@remirror/editor-social/src/components/social-suggestion-components.tsx
@@ -4,6 +4,7 @@ import { Position, RemirrorTheme } from '@remirror/core';
 import { useRemirrorContext } from '@remirror/react';
 import { useRemirrorTheme } from '@remirror/ui';
 import { forwardRef, FunctionComponent } from 'react';
+
 import {
   DivProps,
   ImgProps,

--- a/@remirror/editor-social/src/components/social-wrapper-component.tsx
+++ b/@remirror/editor-social/src/components/social-wrapper-component.tsx
@@ -4,6 +4,7 @@ import { jsx } from '@emotion/core';
 import { EmojiObject, EmojiSuggestCommand } from '@remirror/extension-emoji';
 import { useRemirrorContext } from '@remirror/react';
 import { FC } from 'react';
+
 import {
   ActiveTagData,
   ActiveUserData,
@@ -12,10 +13,10 @@ import {
   SetExitTriggeredInternallyParams,
   SocialExtensions,
 } from '../social-types';
+import { EmojiSuggestions } from './emoji-suggestion-component';
 import { CharacterCountWrapper, EditorWrapper } from './social-base-components';
 import { CharacterCountIndicator } from './social-character-count-component';
 import { AtSuggestions, TagSuggestions } from './social-suggestion-components';
-import { EmojiSuggestions } from './emoji-suggestion-component';
 
 interface SocialEditorComponentProps extends MentionGetterParams, SetExitTriggeredInternallyParams {
   emojiList: EmojiObject[];

--- a/@remirror/editor-social/src/social-utils.ts
+++ b/@remirror/editor-social/src/social-utils.ts
@@ -1,5 +1,6 @@
 import { Attrs, EditorView } from '@remirror/core';
 import { MentionExtensionAttrs } from '@remirror/extension-mention';
+
 import { MentionGetterParams } from './social-types';
 
 /**

--- a/@remirror/editor-wysiwyg/src/__tests__/wysiwyg-ssr.spec.tsx
+++ b/@remirror/editor-wysiwyg/src/__tests__/wysiwyg-ssr.spec.tsx
@@ -2,10 +2,10 @@
  * @jest-environment node
  */
 
+import { docNodeBasicJSON } from '@remirror/test-fixtures';
 import React from 'react';
 import { renderToString } from 'react-dom/server';
 
-import { docNodeBasicJSON } from '@remirror/test-fixtures';
 import { WysiwygEditor } from '..';
 
 test('it renders within an ssr environment', () => {

--- a/@remirror/editor-wysiwyg/src/__tests__/wysiwyg.spec.tsx
+++ b/@remirror/editor-wysiwyg/src/__tests__/wysiwyg.spec.tsx
@@ -1,7 +1,7 @@
+import { docNodeBasicJSON } from '@remirror/test-fixtures';
 import { render } from '@testing-library/react';
 import React from 'react';
 
-import { docNodeBasicJSON } from '@remirror/test-fixtures';
 import { WysiwygEditor } from '..';
 
 test('it renders within an ssr environment', () => {

--- a/@remirror/editor-wysiwyg/src/components/wysiwyg-components.tsx
+++ b/@remirror/editor-wysiwyg/src/components/wysiwyg-components.tsx
@@ -4,6 +4,7 @@ import { RemirrorInterpolation } from '@remirror/core';
 import { useRemirrorTheme } from '@remirror/ui';
 import { ResetButton } from '@remirror/ui-buttons';
 import { FC, forwardRef } from 'react';
+
 import { ButtonProps } from '../wysiwyg-types';
 
 export const Menu = forwardRef<HTMLDivElement, JSX.IntrinsicElements['div']>((props, ref) => {

--- a/@remirror/editor-wysiwyg/src/components/wysiwyg-editor.tsx
+++ b/@remirror/editor-wysiwyg/src/components/wysiwyg-editor.tsx
@@ -32,15 +32,15 @@ import {
 } from '@remirror/react';
 import { RemirrorThemeProvider } from '@remirror/ui';
 import { FC, Fragment, useMemo, useState } from 'react';
-import { wysiwygEditorTheme } from '../wysiwyg-theme';
-import { WysiwygEditorProps, WysiwygExtensions } from '../wysiwyg-types';
-import { EditorWrapper } from './wysiwyg-components';
-import { BubbleMenu, BubbleMenuProps, MenuBar } from './wysiwyg-menu';
-
 import bash from 'refractor/lang/bash';
 import markdown from 'refractor/lang/markdown';
 import tsx from 'refractor/lang/tsx';
 import typescript from 'refractor/lang/typescript';
+
+import { wysiwygEditorTheme } from '../wysiwyg-theme';
+import { WysiwygEditorProps, WysiwygExtensions } from '../wysiwyg-types';
+import { EditorWrapper } from './wysiwyg-components';
+import { BubbleMenu, BubbleMenuProps, MenuBar } from './wysiwyg-menu';
 
 const defaultPlaceholder = 'Start typing...';
 const DEFAULT_LANGUAGES = [markdown, typescript, tsx, bash];

--- a/@remirror/editor-wysiwyg/src/components/wysiwyg-menu.tsx
+++ b/@remirror/editor-wysiwyg/src/components/wysiwyg-menu.tsx
@@ -34,6 +34,7 @@ import {
   useState,
 } from 'react';
 import keyNames from 'w3c-keyname';
+
 import { ButtonState, WysiwygExtensions } from '../wysiwyg-types';
 import {
   BubbleContent,
@@ -148,7 +149,7 @@ const bubbleMenuItems: Array<[
 export const BubbleMenu: FC<BubbleMenuProps> = ({ linkActivated = false, deactivateLink, activateLink }) => {
   const { actions, getPositionerProps, helpers } = useRemirrorContext<WysiwygExtensions>();
 
-  const { bottom, left, ref } = getPositionerProps({
+  const positionerProps = getPositionerProps({
     ...bubblePositioner,
     hasChanged: () => true,
     isActive: params => {
@@ -160,6 +161,8 @@ export const BubbleMenu: FC<BubbleMenuProps> = ({ linkActivated = false, deactiv
     },
     positionerId: 'bubbleMenu',
   });
+
+  const { bottom, ref, left } = positionerProps;
 
   const updateLink = (href: string) => actions.updateLink({ href });
   const removeLink = () => actions.removeLink();
@@ -237,19 +240,19 @@ const LinkInput: FC<LinkInputProps> = ({ deactivateLink, updateLink, removeLink,
     deactivateLink();
   };
 
-  useEffect(() => {
-    document.addEventListener('mousedown', handleClick, false);
-    return () => {
-      document.removeEventListener('mousedown', handleClick, false);
-    };
-  });
-
   const handleClick = (event: MouseEvent) => {
     if (!wrapperRef.current || wrapperRef.current.contains(event.target as Node)) {
       return;
     }
     deactivateLink();
   };
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleClick, false);
+    return () => {
+      document.removeEventListener('mousedown', handleClick, false);
+    };
+  });
 
   return (
     <BubbleContent ref={wrapperRef}>

--- a/@remirror/editor-wysiwyg/src/wysiwyg-theme.ts
+++ b/@remirror/editor-wysiwyg/src/wysiwyg-theme.ts
@@ -1,5 +1,6 @@
 import { EDITOR_CLASS_SELECTOR, RemirrorTheme } from '@remirror/core';
 import { baseTheme } from '@remirror/ui';
+
 import { ButtonState } from './wysiwyg-types';
 
 export const buttonColors: Record<ButtonState, string> = {

--- a/@remirror/editor-wysiwyg/src/wysiwyg-types.ts
+++ b/@remirror/editor-wysiwyg/src/wysiwyg-types.ts
@@ -21,7 +21,7 @@ import {
 import { CodeBlockExtension, CodeBlockExtensionOptions } from '@remirror/extension-code-block';
 import { DropCursorExtension } from '@remirror/extension-drop-cursor';
 import { ImageExtension } from '@remirror/extension-image';
-import { RemirrorProps, RemirrorManagerProps } from '@remirror/react';
+import { RemirrorManagerProps, RemirrorProps } from '@remirror/react';
 
 /**
  * The union type of all the extension used within the Wysiwyg Editor.

--- a/@remirror/extension-code-block/src/__tests__/code-block-ssr.spec.ts
+++ b/@remirror/extension-code-block/src/__tests__/code-block-ssr.spec.ts
@@ -2,13 +2,13 @@
  * @jest-environment node
  */
 
-import { renderSSREditor } from 'jest-remirror';
-import { CodeBlockExtension } from '../';
-
 import { ObjectNode } from '@remirror/core';
+import { renderSSREditor } from 'jest-remirror';
 import javascript from 'refractor/lang/javascript';
 import markdown from 'refractor/lang/markdown';
 import typescript from 'refractor/lang/typescript';
+
+import { CodeBlockExtension } from '../';
 
 const supportedLanguages = [typescript, javascript, markdown];
 const create = (initialContent: ObjectNode) =>

--- a/@remirror/extension-code-block/src/__tests__/code-block.spec.ts
+++ b/@remirror/extension-code-block/src/__tests__/code-block.spec.ts
@@ -8,6 +8,7 @@ import javascript from 'refractor/lang/javascript';
 import markdown from 'refractor/lang/markdown';
 import tsx from 'refractor/lang/tsx';
 import typescript from 'refractor/lang/typescript';
+
 import { CodeBlockExtension, CodeBlockExtensionOptions } from '../';
 import { CodeBlockFormatter } from '../code-block-types';
 import { getLanguage } from '../code-block-utils';

--- a/@remirror/extension-code-block/src/code-block-component.tsx
+++ b/@remirror/extension-code-block/src/code-block-component.tsx
@@ -5,6 +5,7 @@ import { SSRComponentProps } from '@remirror/core';
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
 import SyntaxHighlighter from 'react-syntax-highlighter/dist/cjs/prism-light';
+
 import { CodeBlockAttrs, CodeBlockExtensionOptions } from './code-block-types';
 import { getLanguage } from './code-block-utils';
 

--- a/@remirror/extension-code-block/src/code-block-extension.ts
+++ b/@remirror/extension-code-block/src/code-block-extension.ts
@@ -21,11 +21,12 @@ import {
 import { setBlockType } from 'prosemirror-commands';
 import { TextSelection } from 'prosemirror-state';
 import refractor from 'refractor/core';
+
 import { CodeBlockComponent } from './code-block-component';
 import createCodeBlockPlugin from './code-block-plugin';
 import { CodeBlockAttrs, CodeBlockExtensionOptions } from './code-block-types';
 import { formatCodeBlockFactory, getLanguage, updateNodeAttrs } from './code-block-utils';
-import { syntaxTheme, SyntaxTheme } from './themes';
+import { SyntaxTheme, syntaxTheme } from './themes';
 
 export const codeBlockDefaultOptions: CodeBlockExtensionOptions = {
   SSRComponent: CodeBlockComponent,
@@ -97,7 +98,7 @@ export class CodeBlockExtension extends NodeExtension<CodeBlockExtensionOptions>
         },
       ],
       toDOM: node => {
-        const { language, ...rest } = node.attrs;
+        const { language, ...rest } = node.attrs as CodeBlockAttrs;
         const attrs = { ...rest, class: `language-${language}` };
 
         return ['pre', attrs, ['code', { [dataAttribute]: language }, 0]];
@@ -233,9 +234,9 @@ export class CodeBlockExtension extends NodeExtension<CodeBlockExtensionOptions>
       Backspace: (state, dispatch) => {
         const { selection } = state;
         let tr = state.tr;
-        const parent = findParentNodeOfType({ types: type, selection })!;
+        const parent = findParentNodeOfType({ types: type, selection });
 
-        if (!parent || parent.start !== selection.from) {
+        if (parent?.start !== selection.from) {
           return false;
         }
 

--- a/@remirror/extension-code-block/src/code-block-plugin.ts
+++ b/@remirror/extension-code-block/src/code-block-plugin.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import {
   CompareStateParams,
   EditorState,
@@ -15,6 +16,7 @@ import { keydownHandler } from 'prosemirror-keymap';
 import { Plugin } from 'prosemirror-state';
 import { Step } from 'prosemirror-transform';
 import { DecorationSet } from 'prosemirror-view';
+
 import { CodeBlockExtensionOptions } from './code-block-types';
 import {
   createDecorations,

--- a/@remirror/extension-code-block/src/code-block-types.ts
+++ b/@remirror/extension-code-block/src/code-block-types.ts
@@ -1,5 +1,6 @@
 import { Attrs, NodeExtensionOptions } from '@remirror/core';
 import { RefractorSyntax } from 'refractor/core';
+
 import { SyntaxTheme } from './themes';
 
 export interface CodeBlockExtensionOptions extends NodeExtensionOptions {

--- a/@remirror/extension-code-block/src/code-block-utils.ts
+++ b/@remirror/extension-code-block/src/code-block-utils.ts
@@ -17,16 +17,16 @@ import {
   TextParams,
   uniqueArray,
 } from '@remirror/core';
-import { Decoration } from 'prosemirror-view';
-import refractor, { RefractorNode, RefractorSyntax } from 'refractor/core';
-import { CodeBlockAttrs, CodeBlockExtensionOptions, FormattedContent } from './code-block-types';
-
 // Refractor languages
 import { TextSelection } from 'prosemirror-state';
+import { Decoration } from 'prosemirror-view';
+import refractor, { RefractorNode, RefractorSyntax } from 'refractor/core';
 import clike from 'refractor/lang/clike';
 import css from 'refractor/lang/css';
 import js from 'refractor/lang/javascript';
 import markup from 'refractor/lang/markup';
+
+import { CodeBlockAttrs, CodeBlockExtensionOptions, FormattedContent } from './code-block-types';
 
 interface ParsedRefractorNode extends TextParams {
   /**

--- a/@remirror/extension-collaboration/src/collaboration-extension.ts
+++ b/@remirror/extension-collaboration/src/collaboration-extension.ts
@@ -13,6 +13,7 @@ import {
 } from '@remirror/core';
 import { collab, getVersion, receiveTransaction, sendableSteps } from 'prosemirror-collab';
 import { Step } from 'prosemirror-transform';
+
 import { CollaborationAttrs, CollaborationExtensionOptions } from './collaboration-types';
 
 /**

--- a/@remirror/extension-drop-cursor/src/drop-cursor-component.tsx
+++ b/@remirror/extension-drop-cursor/src/drop-cursor-component.tsx
@@ -1,10 +1,12 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import { numberToPixels, useRemirrorTheme } from '@remirror/ui';
+
+import { defaultDropCursorExtensionOptions } from './drop-cursor-constants';
 import { DropCursorExtensionComponentProps, DropCursorExtensionOptions } from './drop-cursor-types';
 
 type DropCursorComponentProps = Omit<DropCursorExtensionComponentProps, 'options'> & {
-  options: Required<DropCursorExtensionOptions>;
+  options: DropCursorExtensionOptions;
 };
 
 export const DropCursorComponent = ({ options, type, container }: DropCursorComponentProps) => {
@@ -13,13 +15,13 @@ export const DropCursorComponent = ({ options, type, container }: DropCursorComp
   const { Component, ...rest } = options;
 
   return Component ? (
-    <Component options={rest} type={type} container={container} />
+    <Component options={rest as any} type={type} container={container} />
   ) : type === 'block' ? (
     <div
       css={sx({
-        width: numberToPixels(rest.blockWidth),
-        backgroundColor: rest.color,
-        height: numberToPixels(rest.blockHeight),
+        width: numberToPixels(rest.blockWidth ?? defaultDropCursorExtensionOptions.blockWidth),
+        backgroundColor: rest.color ?? defaultDropCursorExtensionOptions.color,
+        height: numberToPixels(rest.blockHeight ?? defaultDropCursorExtensionOptions.blockHeight),
       })}
     />
   ) : (
@@ -28,8 +30,8 @@ export const DropCursorComponent = ({ options, type, container }: DropCursorComp
         display: 'inline',
         backgroundColor: rest.color,
         borderRadius: 0,
-        margin: `0 ${numberToPixels(rest.inlineSpacing)}`,
-        width: numberToPixels(rest.inlineWidth),
+        margin: `0 ${numberToPixels(rest.inlineSpacing ?? defaultDropCursorExtensionOptions.inlineSpacing)}`,
+        width: numberToPixels(rest.inlineWidth ?? defaultDropCursorExtensionOptions.inlineWidth),
       })}
     >
       &nbsp;

--- a/@remirror/extension-drop-cursor/src/drop-cursor-constants.ts
+++ b/@remirror/extension-drop-cursor/src/drop-cursor-constants.ts
@@ -1,0 +1,13 @@
+export const defaultDropCursorExtensionOptions = {
+  inlineWidth: '2px',
+  inlineSpacing: '10px',
+  blockWidth: '100%',
+  blockHeight: '10px',
+  color: 'primary',
+  blockClassName: 'remirror-drop-cursor-block',
+  beforeBlockClassName: 'remirror-drop-cursor-before-block',
+  afterBlockClassName: 'remirror-drop-cursor-after-block',
+  inlineClassName: 'remirror-drop-cursor-inline',
+  beforeInlineClassName: 'remirror-drop-cursor-before-inline',
+  afterInlineClassName: 'remirror-drop-cursor-after-inline',
+};

--- a/@remirror/extension-drop-cursor/src/drop-cursor-extension.ts
+++ b/@remirror/extension-drop-cursor/src/drop-cursor-extension.ts
@@ -1,4 +1,6 @@
 import { Extension, ExtensionManagerParams, getPluginState, Plugin } from '@remirror/core';
+
+import { defaultDropCursorExtensionOptions } from './drop-cursor-constants';
 import { dropCursorPlugin, DropCursorState } from './drop-cursor-plugin';
 import { DropCursorExtensionOptions } from './drop-cursor-types';
 
@@ -12,19 +14,7 @@ export class DropCursorExtension extends Extension<DropCursorExtensionOptions> {
   }
 
   get defaultOptions(): DropCursorExtensionOptions {
-    return {
-      inlineWidth: '2px',
-      inlineSpacing: '10px',
-      blockWidth: '100%',
-      blockHeight: '10px',
-      color: 'primary',
-      blockClassName: 'remirror-drop-cursor-block',
-      beforeBlockClassName: 'remirror-drop-cursor-before-block',
-      afterBlockClassName: 'remirror-drop-cursor-after-block',
-      inlineClassName: 'remirror-drop-cursor-inline',
-      beforeInlineClassName: 'remirror-drop-cursor-before-inline',
-      afterInlineClassName: 'remirror-drop-cursor-after-inline',
-    };
+    return defaultDropCursorExtensionOptions;
   }
 
   public helpers({ getState }: ExtensionManagerParams) {

--- a/@remirror/extension-emoji/src/__tests__/emoji-extension.spec.ts
+++ b/@remirror/extension-emoji/src/__tests__/emoji-extension.spec.ts
@@ -1,5 +1,6 @@
 import { renderEditor } from 'jest-remirror';
 import { SuggestKeyBindingParams } from 'prosemirror-suggest';
+
 import { EmojiExtension } from '../emoji-extension';
 import {
   EmojiExtensionOptions,

--- a/@remirror/extension-emoji/src/emoji-extension.ts
+++ b/@remirror/extension-emoji/src/emoji-extension.ts
@@ -3,11 +3,13 @@ import {
   Extension,
   ExtensionManagerParams,
   FromToParams,
+  isNullOrUndefined,
   noop,
   plainInputRule,
 } from '@remirror/core';
 import escapeStringRegex from 'escape-string-regexp';
 import { Suggester } from 'prosemirror-suggest';
+
 import {
   EmojiExtensionOptions,
   EmojiObject,
@@ -179,7 +181,7 @@ export class EmojiExtension extends Extension<EmojiExtensionOptions> {
         const create = getActions('insertEmojiByObject');
 
         return (emoji, skinVariation) => {
-          if (!emoji) {
+          if (isNullOrUndefined(emoji)) {
             throw new Error('An emoji object is required when calling the emoji suggestions command');
           }
 

--- a/@remirror/extension-emoji/src/emoji-types.ts
+++ b/@remirror/extension-emoji/src/emoji-types.ts
@@ -4,6 +4,7 @@ import {
   SuggestExitHandlerParams,
   SuggestKeyBindingMap,
 } from 'prosemirror-suggest';
+
 import AliasData from './data/aliases';
 import CategoryData from './data/categories';
 import EmojiData from './data/emojis';

--- a/@remirror/extension-emoji/src/emoji-utils.ts
+++ b/@remirror/extension-emoji/src/emoji-utils.ts
@@ -12,6 +12,7 @@ import {
 } from '@remirror/core';
 import escapeStringRegex from 'escape-string-regexp';
 import matchSorter from 'match-sorter';
+
 import aliasObject from './data/aliases';
 import rawEmojiObject from './data/emojis';
 import {

--- a/@remirror/extension-emoji/src/patches.d.ts
+++ b/@remirror/extension-emoji/src/patches.d.ts
@@ -1,6 +1,4 @@
 declare module 'storejs' {
-  export = storejs;
-
   function storejs(key: any, data: any, ...args: any[]): any;
 
   namespace storejs {
@@ -13,4 +11,6 @@ declare module 'storejs' {
     function search(str: any): any;
     function set(key: any, val: any): any;
   }
+
+  export = storejs;
 }

--- a/@remirror/extension-enhanced-link/src/__tests__/enhanced-link.spec.tsx
+++ b/@remirror/extension-enhanced-link/src/__tests__/enhanced-link.spec.tsx
@@ -1,5 +1,6 @@
-import { EnhancedLinkExtension } from '../enhanced-link-extension';
 import { renderSSREditor } from 'jest-remirror';
+
+import { EnhancedLinkExtension } from '../enhanced-link-extension';
 
 test('ssr', () => {
   // const manager = createBaseTestManager([new EnhancedLinkExtension({})]);

--- a/@remirror/extension-enhanced-link/src/enhanced-link-extension.ts
+++ b/@remirror/extension-enhanced-link/src/enhanced-link-extension.ts
@@ -7,6 +7,7 @@ import {
   ExtensionManagerMarkTypeParams,
   findMatches,
   getMatchString,
+  isFunction,
   LEAF_NODE_REPLACING_CHARACTER,
   MarkExtension,
   MarkExtensionOptions,
@@ -17,14 +18,15 @@ import {
 } from '@remirror/core';
 import { Plugin } from 'prosemirror-state';
 import { ReplaceStep } from 'prosemirror-transform';
-import { extractUrl } from './extract-url';
+
 import {
-  extractHref,
-  EnhancedLinkHandlerProps,
   enhancedLinkHandler,
+  EnhancedLinkHandlerProps,
+  extractHref,
   getUrlsFromState,
   isSetEqual,
 } from './enhanced-link-utils';
+import { extractUrl } from './extract-url';
 
 export interface EnhancedLinkExtensionOptions extends MarkExtensionOptions {
   /**
@@ -188,7 +190,7 @@ export class EnhancedLinkExtension extends MarkExtension<EnhancedLinkExtensionOp
       },
       view: () => ({
         update(view: EditorView, prevState: EditorState) {
-          if (!onUrlsChange) {
+          if (!isFunction(onUrlsChange)) {
             return;
           }
 

--- a/@remirror/extension-epic-mode/src/epic-mode-effects.ts
+++ b/@remirror/extension-epic-mode/src/epic-mode-effects.ts
@@ -1,4 +1,5 @@
 import { randomInt } from '@remirror/core';
+
 import { ParticleEffect } from './epic-mode-types';
 
 export const COLORS = [
@@ -67,6 +68,9 @@ export const defaultEffect: ParticleEffect = {
   },
 };
 
+const DEFAULT_SPAWNING_DRAG = 0.92;
+const createSpawningTheta = () => (randomInt(0, 360) * Math.PI) / 180;
+
 export const spawningEffect: ParticleEffect = {
   createParticle({ x, y, color }) {
     return {
@@ -75,21 +79,21 @@ export const spawningEffect: ParticleEffect = {
       alpha: 1,
       color,
       size: randomInt(2, 8),
-      drag: 0.92,
+      drag: DEFAULT_SPAWNING_DRAG,
       vx: randomInt(-3, 3),
       vy: randomInt(-3, 3),
       wander: 0.15,
-      theta: (randomInt(0, 360) * Math.PI) / 180,
+      theta: createSpawningTheta(),
     };
   },
   updateParticle({ particle, ctx }) {
     particle.x += particle.vx;
     particle.y += particle.vy;
-    particle.vx *= particle.drag!;
-    particle.vy *= particle.drag!;
-    particle.theta! += randomInt(-0.5, 0.5);
-    particle.vx += Math.sin(particle.theta!) * 0.1;
-    particle.vy += Math.cos(particle.theta!) * 0.1;
+    particle.vx *= particle.drag ?? DEFAULT_SPAWNING_DRAG;
+    particle.vy *= particle.drag ?? DEFAULT_SPAWNING_DRAG;
+    particle.theta = (particle.theta ?? createSpawningTheta()) + randomInt(-0.5, 0.5);
+    particle.vx += Math.sin(particle.theta) * 0.1;
+    particle.vy += Math.cos(particle.theta) * 0.1;
     particle.size *= 0.96;
 
     ctx.fillStyle = `rgba(${particle.color[0]},${particle.color[1]},${particle.color[2]},${particle.alpha})`;

--- a/@remirror/extension-epic-mode/src/epic-mode-extension.ts
+++ b/@remirror/extension-epic-mode/src/epic-mode-extension.ts
@@ -1,7 +1,8 @@
 import { Extension, ProsemirrorPlugin } from '@remirror/core';
+
 import { defaultEffect, PARTICLE_NUM_RANGE, VIBRANT_COLORS } from './epic-mode-effects';
-import { EpicModeExtensionOptions } from './epic-mode-types';
 import { createEpicModePlugin } from './epic-mode-plugin';
+import { EpicModeExtensionOptions } from './epic-mode-types';
 
 export const defaultEpicModeExtensionOptions: EpicModeExtensionOptions = {
   particleEffect: defaultEffect,

--- a/@remirror/extension-epic-mode/src/epic-mode-plugin.ts
+++ b/@remirror/extension-epic-mode/src/epic-mode-plugin.ts
@@ -1,5 +1,6 @@
 import { EditorSchema, Extension, getPluginState } from '@remirror/core';
 import { Plugin } from 'prosemirror-state';
+
 import { EpicModePluginState } from './epic-mode-state';
 import { EpicModeExtensionOptions } from './epic-mode-types';
 

--- a/@remirror/extension-epic-mode/src/epic-mode-state.ts
+++ b/@remirror/extension-epic-mode/src/epic-mode-state.ts
@@ -1,4 +1,5 @@
 import { EditorView, randomInt, throttle } from '@remirror/core';
+
 import { EpicModePluginStateParams, Particle, ParticleEffect, ParticleRange } from './epic-mode-types';
 
 const getRGBComponents = (node: Element) => {
@@ -70,7 +71,7 @@ export class EpicModePluginState {
     const ctx = canvas.getContext('2d');
 
     if (!ctx) {
-      throw new Error('An error occured while creating the canvas context');
+      throw new Error('An error occurred while creating the canvas context');
     }
 
     this.ctx = ctx;

--- a/@remirror/extension-image/src/image-extension.ts
+++ b/@remirror/extension-image/src/image-extension.ts
@@ -9,6 +9,7 @@ import {
   NodeExtensionSpec,
 } from '@remirror/core';
 import { ResolvedPos } from 'prosemirror-model';
+
 import { createImageExtensionPlugin } from './image-plugin';
 import { getAttrs } from './image-utils';
 

--- a/@remirror/extension-image/src/image-utils.ts
+++ b/@remirror/extension-image/src/image-utils.ts
@@ -1,5 +1,6 @@
 import { Attrs } from '@remirror/core';
 import { CSS_ROTATE_PATTERN, EMPTY_CSS_VALUE } from '@remirror/core-extensions';
+
 import { IMAGE_FILE_TYPES } from './image-constants';
 
 /**

--- a/@remirror/extension-mention/src/__tests__/mention.spec.ts
+++ b/@remirror/extension-mention/src/__tests__/mention.spec.ts
@@ -2,8 +2,9 @@ import { fromHTML, toHTML } from '@remirror/core';
 import { createBaseTestManager } from '@remirror/test-fixtures';
 import { pmBuild } from 'jest-prosemirror';
 import { renderEditor } from 'jest-remirror';
-import { MentionExtension, MentionExtensionOptions } from '../';
 import { SuggestCommandParams } from 'prosemirror-suggest';
+
+import { MentionExtension, MentionExtensionOptions } from '../';
 import { MentionExtensionSuggestCommand } from '../mention-types';
 
 describe('schema', () => {

--- a/@remirror/extension-mention/src/mention-extension.ts
+++ b/@remirror/extension-mention/src/mention-extension.ts
@@ -6,33 +6,35 @@ import {
   getMarkRange,
   getMatchString,
   isElementDOMNode,
+  isMarkActive,
   MarkExtension,
   MarkExtensionSpec,
   MarkGroup,
   markPasteRule,
   MarkType,
+  noop,
   RangeParams,
   removeMark,
   replaceText,
   TransactionTransformer,
-  noop,
-  isMarkActive,
 } from '@remirror/core';
 import {
-  MentionExtensionOptions,
-  SuggestionCommandAttrs,
-  MentionExtensionSuggestCommand,
-} from './mention-types';
-import { DEFAULT_MATCHER, isValidMentionAttrs, getMatcher, getAppendText } from './mention-utils';
-import {
-  Suggester,
-  isSplitReason,
+  escapeChar,
+  getRegexPrefix,
   isInvalidSplitReason,
   isRemovedReason,
-  getRegexPrefix,
-  escapeChar,
+  isSplitReason,
   regexToString,
+  Suggester,
 } from 'prosemirror-suggest';
+
+import {
+  MentionExtensionAttrs,
+  MentionExtensionOptions,
+  MentionExtensionSuggestCommand,
+  SuggestionCommandAttrs,
+} from './mention-types';
+import { DEFAULT_MATCHER, getAppendText, getMatcher, isValidMentionAttrs } from './mention-utils';
 
 const defaultHandler = () => false;
 
@@ -93,7 +95,9 @@ export class MentionExtension extends MarkExtension<MentionExtensionOptions> {
         },
       ],
       toDOM: node => {
-        const { label: _, id, name, ...attrs } = node.attrs;
+        const { label: _, id, name, replacementType, range, ...attrs } = node.attrs as Required<
+          MentionExtensionAttrs
+        >;
         const matcher = this.options.matchers.find(matcher => matcher.name === name);
         const mentionClassName = matcher
           ? matcher.mentionClassName ?? DEFAULT_MATCHER.mentionClassName

--- a/@remirror/extension-mention/src/mention-types.ts
+++ b/@remirror/extension-mention/src/mention-types.ts
@@ -1,5 +1,5 @@
 import { Attrs, MarkExtensionOptions } from '@remirror/core';
-import { SuggestReplacementType, Suggester, FromToEndParams } from 'prosemirror-suggest';
+import { FromToEndParams, Suggester, SuggestReplacementType } from 'prosemirror-suggest';
 
 export interface OptionalMentionExtensionParams {
   /**

--- a/@remirror/extension-mention/src/mention-utils.ts
+++ b/@remirror/extension-mention/src/mention-utils.ts
@@ -1,6 +1,7 @@
-import { bool, Attrs, isPlainObject, pick, isString } from '@remirror/core';
-import { MentionExtensionAttrs, MentionExtensionMatcher } from './mention-types';
+import { Attrs, bool, isPlainObject, isString, pick } from '@remirror/core';
 import { DEFAULT_SUGGESTER } from 'prosemirror-suggest';
+
+import { MentionExtensionAttrs, MentionExtensionMatcher } from './mention-types';
 
 /**
  * The default matcher to use when none is provided in options

--- a/@remirror/react-hooks/src/__tests__/react-hooks.spec.tsx
+++ b/@remirror/react-hooks/src/__tests__/react-hooks.spec.tsx
@@ -1,6 +1,7 @@
 import { act, render } from '@testing-library/react';
 import { act as hookAct, renderHook } from '@testing-library/react-hooks';
 import React from 'react';
+
 import { fakeResizeObserverPolyfill, triggerChange } from '../../__mocks__/resize-observer-polyfill';
 import { useMeasure, usePrevious, useSetState, useStateWithCallback } from '../react-hooks';
 

--- a/@remirror/react-node-view/src/react-node-view.tsx
+++ b/@remirror/react-node-view/src/react-node-view.tsx
@@ -2,7 +2,7 @@
 
 import { jsx } from '@emotion/core';
 import { EDITOR_CLASS_NAME, SELECTED_NODE_CLASS_NAME } from '@remirror/core-constants';
-import { isPlainObject, isString, isFunction, keys } from '@remirror/core-helpers';
+import { isFunction, isPlainObject, isString, keys } from '@remirror/core-helpers';
 import {
   Attrs,
   BaseExtensionOptions,
@@ -15,6 +15,7 @@ import {
 import { isDOMNode, isElementDOMNode } from '@remirror/core-utils';
 import { PortalContainer } from '@remirror/react-portals';
 import { ComponentType } from 'react';
+
 import {
   CreateNodeViewParams,
   GetPosition,

--- a/@remirror/react-portals/src/__tests__/portal-container.spec.tsx
+++ b/@remirror/react-portals/src/__tests__/portal-container.spec.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { PortalContainer } from '..';
 
 test('PortalContainer', () => {

--- a/@remirror/react-portals/src/__tests__/react-portals.spec.tsx
+++ b/@remirror/react-portals/src/__tests__/react-portals.spec.tsx
@@ -1,6 +1,7 @@
 import { RemirrorManager, useRemirrorManager } from '@remirror/react';
 import { act, render } from '@testing-library/react';
 import React from 'react';
+
 import { PortalContainer, RemirrorPortals } from '..';
 
 describe('RemirrorPortals', () => {

--- a/@remirror/react-renderer/src/__tests__/react-serializer.spec.tsx
+++ b/@remirror/react-renderer/src/__tests__/react-serializer.spec.tsx
@@ -7,10 +7,11 @@ import {
   TextExtension,
 } from '@remirror/core';
 import { BoldExtension, CodeBlockExtension, ParagraphExtension } from '@remirror/core-extensions';
-import { simpleJSON, testJSON, createTestManager } from '@remirror/test-fixtures';
+import { createTestManager, simpleJSON, testJSON } from '@remirror/test-fixtures';
 import { shallow } from 'enzyme';
 import { Node as PMNode } from 'prosemirror-model';
 import React from 'react';
+
 import { ReactSerializer } from '../react-serializer';
 
 class FooExtension extends NodeExtension {

--- a/@remirror/react-renderer/src/react-serializer.tsx
+++ b/@remirror/react-renderer/src/react-serializer.tsx
@@ -3,6 +3,7 @@
 import { jsx } from '@emotion/core';
 import {
   AnyExtension,
+  bool,
   DOMOutputSpec,
   ExtensionManager,
   Fragment as ProsemirrorFragment,
@@ -14,10 +15,10 @@ import {
   NodeExtensionSpec,
   PlainObject,
   ProsemirrorNode,
-  bool,
 } from '@remirror/core';
 import { ComponentType, Fragment, ReactNode } from 'react';
-import { mapProps, gatherToDOM } from './renderer-utils';
+
+import { gatherToDOM, mapProps } from './renderer-utils';
 
 type NodeToDOM = NodeExtensionSpec['toDOM'];
 type MarkToDOM = MarkExtensionSpec['toDOM'];

--- a/@remirror/react-renderer/src/renderer-utils.ts
+++ b/@remirror/react-renderer/src/renderer-utils.ts
@@ -1,4 +1,5 @@
-import { PlainObject, hasOwnProperty, MarkExtensionSpec, NodeExtensionSpec } from '@remirror/core';
+import { hasOwnProperty, MarkExtensionSpec, NodeExtensionSpec, PlainObject } from '@remirror/core';
+
 import { possibleStandardNames } from './renderer-constants';
 
 const getPossibleStandardName = (key: string): string => {

--- a/@remirror/react-renderer/src/renderer.tsx
+++ b/@remirror/react-renderer/src/renderer.tsx
@@ -1,8 +1,8 @@
 /** @jsx jsx */
 
 import { jsx } from '@emotion/core';
-import { ComponentType, FC, Fragment } from 'react';
 import { isString, ObjectMark, ObjectNode } from '@remirror/core';
+import { ComponentType, FC, Fragment } from 'react';
 
 /* Inspired by https://github.com/rexxars/react-prosemirror-document */
 

--- a/@remirror/react-ssr/src/__tests__/remirror-ssr.server.spec.tsx
+++ b/@remirror/react-ssr/src/__tests__/remirror-ssr.server.spec.tsx
@@ -5,10 +5,10 @@
 /** @jsx jsx */
 
 import { jsx } from '@emotion/core';
+import { ExtensionManager } from '@remirror/core';
 import { createTestManager, helpers, initialJson } from '@remirror/test-fixtures';
 import { renderToString } from 'react-dom/server';
 
-import { ExtensionManager } from '@remirror/core';
 import { RemirrorSSR } from '..';
 
 let manager: ExtensionManager;

--- a/@remirror/react-ssr/src/__tests__/remirror-ssr.spec.tsx
+++ b/@remirror/react-ssr/src/__tests__/remirror-ssr.spec.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
-
+import { ExtensionManager } from '@remirror/core';
 import { createTestManager, helpers, initialJson } from '@remirror/test-fixtures';
 import { render } from '@testing-library/react';
+import React from 'react';
 
-import { ExtensionManager } from '@remirror/core';
 import { RemirrorSSR } from '..';
 
 let manager: ExtensionManager;

--- a/@remirror/react-ssr/src/__tests__/view-ssr.spec.ts
+++ b/@remirror/react-ssr/src/__tests__/view-ssr.spec.ts
@@ -4,6 +4,7 @@
 
 import { initialJson, plugins, schema, testDocument } from '@remirror/test-fixtures';
 import { EditorState } from 'prosemirror-state';
+
 import { createEditorView, EditorViewSSR } from '../prosemirror-view-ssr';
 
 const state = EditorState.create({ doc: schema.nodeFromJSON(initialJson), schema, plugins });

--- a/@remirror/react-utils/src/__tests__/react-util-helpers-ssr.spec.tsx
+++ b/@remirror/react-utils/src/__tests__/react-util-helpers-ssr.spec.tsx
@@ -3,8 +3,8 @@
  */
 
 import React from 'react';
-
 import { renderToStaticMarkup } from 'react-dom/server';
+
 import { cloneElement } from '../react-utils';
 
 describe('cloneElement', () => {

--- a/@remirror/react-utils/src/__tests__/react-util-helpers.spec.tsx
+++ b/@remirror/react-utils/src/__tests__/react-util-helpers.spec.tsx
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react';
 import React from 'react';
+
 import {
   cloneElement,
   getElementProps,

--- a/@remirror/react/src/__tests__/react-helpers.spec.tsx
+++ b/@remirror/react/src/__tests__/react-helpers.spec.tsx
@@ -2,6 +2,7 @@ import { AnyExtension, ExtensionManager } from '@remirror/core';
 import { PlaceholderExtension } from '@remirror/core-extensions';
 import { TestExtension } from '@remirror/test-fixtures';
 import React, { FC } from 'react';
+
 import { RemirrorExtension } from '../components/remirror-extension';
 import { RemirrorManager } from '../components/remirror-manager';
 import { getManagerFromComponentTree } from '../react-helpers';

--- a/@remirror/react/src/__tests__/react-hooks.spec.tsx
+++ b/@remirror/react/src/__tests__/react-hooks.spec.tsx
@@ -1,6 +1,7 @@
-import { injectedPropsShape, positionerShape, createTestManager } from '@remirror/test-fixtures';
+import { createTestManager, injectedPropsShape, positionerShape } from '@remirror/test-fixtures';
 import { render } from '@testing-library/react';
 import React, { FC } from 'react';
+
 import { RemirrorProvider } from '../components/remirror-providers';
 import { usePositioner, useRemirrorContext } from '../hooks/context-hooks';
 import { bubblePositioner } from '../react-positioners';

--- a/@remirror/react/src/components/__tests__/providers-server.spec.tsx
+++ b/@remirror/react/src/components/__tests__/providers-server.spec.tsx
@@ -5,8 +5,9 @@
 /** @jsx jsx */
 
 import { jsx } from '@emotion/core';
-import { docNodeBasicJSON, createTestManager } from '@remirror/test-fixtures';
+import { createTestManager, docNodeBasicJSON } from '@remirror/test-fixtures';
 import { renderToStaticMarkup } from 'react-dom/server';
+
 import { useRemirrorContext } from '../../hooks/context-hooks';
 import { RemirrorManager } from '../remirror-manager';
 import { ManagedRemirrorProvider, RemirrorProvider } from '../remirror-providers';

--- a/@remirror/react/src/components/__tests__/providers.spec.tsx
+++ b/@remirror/react/src/components/__tests__/providers.spec.tsx
@@ -1,9 +1,10 @@
 /** @jsx jsx */
 
 import { jsx } from '@emotion/core';
-import { docNodeBasicJSON, createBaseTestManager } from '@remirror/test-fixtures';
+import { createBaseTestManager, docNodeBasicJSON } from '@remirror/test-fixtures';
 import { render } from '@testing-library/react';
 import { FC } from 'react';
+
 import { useRemirrorContext } from '../../hooks/context-hooks';
 import { RemirrorManager } from '../remirror-manager';
 import { ManagedRemirrorProvider, RemirrorProvider } from '../remirror-providers';

--- a/@remirror/react/src/components/__tests__/remirror-controlled.spec.tsx
+++ b/@remirror/react/src/components/__tests__/remirror-controlled.spec.tsx
@@ -2,6 +2,7 @@ import { EditorState, fromHTML } from '@remirror/core';
 import { createTestManager } from '@remirror/test-fixtures';
 import { act, render } from '@testing-library/react';
 import React, { useState } from 'react';
+
 import { Remirror } from '..';
 import { InjectedRemirrorProps, RemirrorStateListenerParams } from '../../react-types';
 import { RemirrorProviderProps } from '../remirror-providers';

--- a/@remirror/react/src/components/__tests__/remirror-get-positioner-props.spec.tsx
+++ b/@remirror/react/src/components/__tests__/remirror-get-positioner-props.spec.tsx
@@ -2,6 +2,7 @@ import { PlainObject } from '@remirror/core';
 import { createTestManager } from '@remirror/test-fixtures';
 import { render } from '@testing-library/react';
 import React, { forwardRef, FunctionComponent, RefAttributes } from 'react';
+
 import { Remirror } from '..';
 
 const mock = jest.fn();

--- a/@remirror/react/src/components/__tests__/remirror-get-root-props.spec.tsx
+++ b/@remirror/react/src/components/__tests__/remirror-get-root-props.spec.tsx
@@ -5,6 +5,7 @@ import { createTestManager } from '@remirror/test-fixtures';
 import { render, RenderResult } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import { forwardRef, FunctionComponent, Ref, RefAttributes } from 'react';
+
 import { Remirror } from '..';
 
 const mock = jest.fn();

--- a/@remirror/react/src/components/__tests__/remirror-manager-server.spec.tsx
+++ b/@remirror/react/src/components/__tests__/remirror-manager-server.spec.tsx
@@ -6,6 +6,7 @@ import { PlaceholderExtension } from '@remirror/core-extensions';
 import { docNodeBasicJSON, TestExtension } from '@remirror/test-fixtures';
 import React, { FC } from 'react';
 import { renderToString } from 'react-dom/server';
+
 import { useRemirrorManager } from '../../hooks/context-hooks';
 import { RemirrorExtension } from '../remirror-extension';
 import { RemirrorManager } from '../remirror-manager';

--- a/@remirror/react/src/components/__tests__/remirror-manager.spec.tsx
+++ b/@remirror/react/src/components/__tests__/remirror-manager.spec.tsx
@@ -4,6 +4,7 @@ import { TestExtension } from '@remirror/test-fixtures';
 import { render, RenderResult } from '@testing-library/react';
 import { EditorView } from 'prosemirror-view';
 import React, { FC } from 'react';
+
 import { useRemirrorManager } from '../../hooks/context-hooks';
 import { RemirrorExtension } from '../remirror-extension';
 import { RemirrorManager } from '../remirror-manager';

--- a/@remirror/react/src/components/__tests__/remirror-server.spec.tsx
+++ b/@remirror/react/src/components/__tests__/remirror-server.spec.tsx
@@ -6,9 +6,10 @@
 
 import { jsx } from '@emotion/core';
 import { EDITOR_CLASS_NAME } from '@remirror/core';
-import { docNodeSimpleJSON, createTestManager } from '@remirror/test-fixtures';
+import { createTestManager, docNodeSimpleJSON } from '@remirror/test-fixtures';
 import { Fragment } from 'react';
 import { renderToString } from 'react-dom/server';
+
 import { Remirror } from '..';
 
 const label = 'Remirror editor';

--- a/@remirror/react/src/components/__tests__/remirror.spec.tsx
+++ b/@remirror/react/src/components/__tests__/remirror.spec.tsx
@@ -4,6 +4,7 @@ import { fireEvent, render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import React from 'react';
 import { renderToString } from 'react-dom/server';
+
 import { Remirror } from '../';
 import { InjectedRemirrorProps } from '../../react-types';
 

--- a/@remirror/react/src/components/remirror-extension.tsx
+++ b/@remirror/react/src/components/remirror-extension.tsx
@@ -1,5 +1,6 @@
 import { AbstractInstanceType, AnyExtension, OptionsOfExtension } from '@remirror/core';
 import { RemirrorFC, RemirrorType } from '@remirror/react-utils';
+
 import { RemirrorExtensionProps } from '../react-types';
 
 /**

--- a/@remirror/react/src/components/remirror-manager.tsx
+++ b/@remirror/react/src/components/remirror-manager.tsx
@@ -3,14 +3,15 @@
 import { jsx } from '@emotion/core';
 import {
   AnyExtension,
-  ExtensionManager,
-  PrioritizedExtension,
-  FlexibleExtension,
   convertToPrioritizedExtension,
+  ExtensionManager,
+  FlexibleExtension,
+  PrioritizedExtension,
 } from '@remirror/core';
 import { baseExtensions } from '@remirror/core-extensions';
 import { asDefaultProps, isReactFragment, isRemirrorExtension } from '@remirror/react-utils';
 import { Children, Component, ReactNode } from 'react';
+
 import { RemirrorManagerContext } from '../react-contexts';
 
 export interface RemirrorManagerProps {

--- a/@remirror/react/src/components/remirror-providers.tsx
+++ b/@remirror/react/src/components/remirror-providers.tsx
@@ -4,6 +4,7 @@ import { jsx } from '@emotion/core';
 import { AnyExtension, MakeOptional } from '@remirror/core';
 import { oneChildOnly, RemirrorType } from '@remirror/react-utils';
 import { ProviderProps, ReactElement } from 'react';
+
 import { useRemirrorManager } from '../hooks/context-hooks';
 import { defaultProps } from '../react-constants';
 import { RemirrorContext } from '../react-contexts';

--- a/@remirror/react/src/components/remirror.tsx
+++ b/@remirror/react/src/components/remirror.tsx
@@ -38,6 +38,7 @@ import {
 import { RemirrorThemeContext } from '@remirror/ui';
 import { EditorState } from 'prosemirror-state';
 import { Fragment, PureComponent, ReactNode, Ref } from 'react';
+
 import { defaultProps } from '../react-constants';
 import { defaultPositioner } from '../react-positioners';
 import {

--- a/@remirror/react/src/hooks/context-hooks.ts
+++ b/@remirror/react/src/hooks/context-hooks.ts
@@ -1,5 +1,6 @@
 import { AnyExtension, ExtensionManager } from '@remirror/core';
 import { useContext } from 'react';
+
 import { RemirrorContext, RemirrorManagerContext } from '../react-contexts';
 import { InjectedRemirrorProps, UsePositionerParams } from '../react-types';
 

--- a/@remirror/react/src/react-constants.ts
+++ b/@remirror/react/src/react-constants.ts
@@ -1,5 +1,6 @@
 import { EMPTY_PARAGRAPH_NODE, Transaction } from '@remirror/core';
 import { asDefaultProps } from '@remirror/react-utils';
+
 import { RemirrorProps } from './react-types';
 
 export const defaultProps = asDefaultProps<RemirrorProps>()({

--- a/@remirror/react/src/react-contexts.ts
+++ b/@remirror/react/src/react-contexts.ts
@@ -1,5 +1,6 @@
 import { ExtensionManager } from '@remirror/core';
 import { createContext } from 'react';
+
 import { InjectedRemirrorProps } from './react-types';
 
 /**

--- a/@remirror/react/src/react-helpers.tsx
+++ b/@remirror/react/src/react-helpers.tsx
@@ -4,6 +4,7 @@ import { jsx } from '@emotion/core';
 import { ExtensionManager, PlainObject } from '@remirror/core';
 import { ComponentType } from 'react';
 import { renderToString } from 'react-dom/server';
+
 import { useRemirrorManager } from './hooks/context-hooks';
 
 export interface GetManagerFromComponentTreeParams {

--- a/@remirror/react/src/react-positioners.ts
+++ b/@remirror/react/src/react-positioners.ts
@@ -1,4 +1,5 @@
-import { absoluteCoordinates, isEmptyParagraphNode, selectionEmpty, bool } from '@remirror/core';
+import { absoluteCoordinates, bool, isEmptyParagraphNode, selectionEmpty } from '@remirror/core';
+
 import { Positioner } from './react-types';
 
 export const defaultPositioner: Positioner = {

--- a/@remirror/react/src/react-types.ts
+++ b/@remirror/react/src/react-types.ts
@@ -273,7 +273,7 @@ export type GetPositionerPropsConfig<
   Partial<Omit<CalculatePositionerParams<GExtension>, 'positionerId'>> &
   PositionerIdParams;
 
-export interface RefParams<GRefKey extends string = 'ref'> {
+export interface RefParams<GRefKey = 'ref'> {
   /**
    * A custom ref key which allows a reference to be obtained from non standard
    * components.
@@ -293,8 +293,11 @@ export type RefKeyRootProps<GRefKey extends string = 'ref'> = {
   [P in Exclude<GRefKey, 'key'>]: Ref<any>;
 } & { css: Interpolation | ((theme: any) => Interpolation); key: string; children: ReactNode } & PlainObject;
 
-export type GetPositionerReturn<GRefKey extends string = 'ref'> = PositionerProps &
-  { [P in GRefKey]: Ref<any> };
+export type GetPositionerReturn<GRefKey extends string = 'ref'> =
+  // GRefKey extends 'ref'
+  //   ? PositionerProps & { ref: Ref<any> }
+  // :
+  PositionerProps & { [P in GRefKey]: Ref<any> };
 
 /**
  * These are the props passed to the render function provided when setting up

--- a/@remirror/showcase/src/__stories__/epic.stories.tsx
+++ b/@remirror/showcase/src/__stories__/epic.stories.tsx
@@ -1,5 +1,6 @@
 import { storiesOf } from '@storybook/react';
 import React from 'react';
+
 import { EpicModeDefault, EpicModeHeart, EpicModeSpawning } from '../epic-mode';
 
 storiesOf('EpicMode Example', module)

--- a/@remirror/showcase/src/__stories__/markdown.stories.tsx
+++ b/@remirror/showcase/src/__stories__/markdown.stories.tsx
@@ -1,6 +1,7 @@
 import { ProsemirrorDevTools } from '@remirror/dev';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
+
 import { ExampleMarkdownEditor } from '../markdown';
 
 storiesOf('Markdown Editor', module).add('Basic', () => (

--- a/@remirror/showcase/src/__stories__/social.stories.tsx
+++ b/@remirror/showcase/src/__stories__/social.stories.tsx
@@ -1,5 +1,6 @@
 import { storiesOf } from '@storybook/react';
 import React from 'react';
+
 import { ExampleSocialEditor, SOCIAL_SHOWCASE_CONTENT } from '../social';
 
 storiesOf('Social Editor', module).add('Basic', () => <ExampleSocialEditor />);

--- a/@remirror/showcase/src/__stories__/wysiwyg.stories.tsx
+++ b/@remirror/showcase/src/__stories__/wysiwyg.stories.tsx
@@ -1,6 +1,7 @@
 import { ProsemirrorDevTools } from '@remirror/dev';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
+
 import { ExampleWysiwygEditor, WYSIWYG_SHOWCASE_CONTENT } from '../wysiwyg';
 
 storiesOf('Wysiwyg Editor', module)

--- a/@remirror/showcase/src/social.tsx
+++ b/@remirror/showcase/src/social.tsx
@@ -1,8 +1,7 @@
 /** @jsx jsx */
 
 import { jsx } from '@emotion/core';
-import { useState } from 'react';
-
+import { startCase, take } from '@remirror/core';
 import {
   ActiveTagData,
   ActiveUserData,
@@ -11,9 +10,9 @@ import {
   SocialEditorProps,
   UserData,
 } from '@remirror/editor-social';
-
-import { startCase, take } from '@remirror/core';
 import matchSorter from 'match-sorter';
+import { useState } from 'react';
+
 import { fakeUsers } from './data/fake-users';
 
 const fakeTags = [

--- a/@remirror/showcase/src/wysiwyg.tsx
+++ b/@remirror/showcase/src/wysiwyg.tsx
@@ -4,6 +4,7 @@ import { jsx } from '@emotion/core';
 import { EMPTY_PARAGRAPH_NODE } from '@remirror/core';
 import { WysiwygEditor, WysiwygEditorProps } from '@remirror/editor-wysiwyg';
 import { FC } from 'react';
+
 import { formatter } from './code-formatter';
 
 export const ExampleWysiwygEditor: FC<WysiwygEditorProps> = ({

--- a/@remirror/test-fixtures/src/schema-helpers.ts
+++ b/@remirror/test-fixtures/src/schema-helpers.ts
@@ -1,25 +1,25 @@
 import {
-  DocExtension,
-  ExtensionManager,
-  TextExtension,
-  Cast,
-  Extension,
   BaseExtensionOptions,
+  Cast,
+  DocExtension,
+  Extension,
+  ExtensionManager,
   FlexibleExtension,
+  TextExtension,
 } from '@remirror/core';
 import {
-  ParagraphExtension,
+  BlockquoteExtension,
   BoldExtension,
+  HeadingExtension,
+  HistoryExtension,
   ItalicExtension,
+  ParagraphExtension,
   PlaceholderExtension,
   UnderlineExtension,
-  BlockquoteExtension,
-  HistoryExtension,
-  HeadingExtension,
 } from '@remirror/core-extensions';
-import minDocument from 'min-document';
 import { PortalContainer } from '@remirror/react-portals';
 import { defaultRemirrorThemeValue } from '@remirror/ui';
+import minDocument from 'min-document';
 
 export const helpers = {
   getState: Cast(jest.fn()),

--- a/@remirror/ui-buttons/src/__stories__/buttons.stories.tsx
+++ b/@remirror/ui-buttons/src/__stories__/buttons.stories.tsx
@@ -3,6 +3,7 @@ import { jsx } from '@emotion/core';
 import { useRemirrorTheme } from '@remirror/ui';
 import { storiesOf } from '@storybook/react';
 import { FC } from 'react';
+
 import { Button } from '..';
 
 const Grid: FC = ({ children }) => {

--- a/@remirror/ui-buttons/src/button.tsx
+++ b/@remirror/ui-buttons/src/button.tsx
@@ -10,6 +10,7 @@ import { useRemirrorTheme } from '@remirror/ui';
 import { IconProps } from '@remirror/ui-icons';
 import { MinWidthProperty, WidthProperty } from 'csstype';
 import { ComponentType, forwardRef, ReactNode } from 'react';
+
 import { ResetButton, ResetButtonProps } from './reset-button';
 
 export interface RenderIconParams {

--- a/@remirror/ui-dropdown/src/__stories__/dropdown.stories.tsx
+++ b/@remirror/ui-dropdown/src/__stories__/dropdown.stories.tsx
@@ -4,6 +4,7 @@ import { capitalize } from '@remirror/core-helpers';
 import { useRemirrorTheme } from '@remirror/ui';
 import { storiesOf } from '@storybook/react';
 import { FC } from 'react';
+
 import { DropdownSelect } from '../dropdown';
 import { DropdownProps } from '../dropdown-types';
 

--- a/@remirror/ui-dropdown/src/__tests__/dropdown-button.spec.tsx
+++ b/@remirror/ui-dropdown/src/__tests__/dropdown-button.spec.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render } from '@testing-library/react';
 import React, { useState } from 'react';
+
 import { DropdownSelect } from '../dropdown';
 import { DropdownItem } from '../dropdown-types';
 

--- a/@remirror/ui-dropdown/src/dropdown-types.ts
+++ b/@remirror/ui-dropdown/src/dropdown-types.ts
@@ -2,6 +2,7 @@ import { IconProps } from '@remirror/ui-icons';
 import { MinWidthProperty, WidthProperty } from 'csstype';
 import { MultishiftChangeHandlerProps, MultishiftPropGetters } from 'multishift';
 import { ComponentType, ReactNode } from 'react';
+
 import { dropdownPositions } from './dropdown-constants';
 
 export interface DropdownItem {

--- a/@remirror/ui-dropdown/src/dropdown.tsx
+++ b/@remirror/ui-dropdown/src/dropdown.tsx
@@ -8,6 +8,7 @@ import { Label } from '@remirror/ui-text';
 import { MultishiftPropGetters, Type, useMultishift } from 'multishift';
 import { forwardRef, useLayoutEffect, useRef, useState } from 'react';
 import { animated, useSpring } from 'react-spring';
+
 import { dropdownPositions } from './dropdown-constants';
 import { DropdownItem, DropdownPosition, DropdownProps } from './dropdown-types';
 import { transformDropdownPosition } from './dropdown-utils';

--- a/@remirror/ui-icons/src/__stories__/icons.stories.tsx
+++ b/@remirror/ui-icons/src/__stories__/icons.stories.tsx
@@ -4,6 +4,7 @@ import { kebabCase } from '@remirror/core-helpers';
 import { useRemirrorTheme } from '@remirror/ui';
 import { storiesOf } from '@storybook/react';
 import { FC } from 'react';
+
 import * as BaseIcons from '../base';
 import * as EditorIcons from '../editor';
 

--- a/@remirror/ui-icons/src/__tests__/base-icon.spec.tsx
+++ b/@remirror/ui-icons/src/__tests__/base-icon.spec.tsx
@@ -2,6 +2,7 @@ import { Merge } from '@remirror/core-helpers';
 import { baseTheme, RemirrorThemeProvider } from '@remirror/ui';
 import { render } from '@testing-library/react';
 import React from 'react';
+
 import { Icon } from '../base-icon';
 
 describe('styles', () => {

--- a/@remirror/ui-icons/src/base-icon.tsx
+++ b/@remirror/ui-icons/src/base-icon.tsx
@@ -4,7 +4,7 @@ import VisuallyHidden from '@reach/visually-hidden';
 import { omitUndefined, uniqueId } from '@remirror/core-helpers';
 import { KeyOfThemeVariant, RemirrorInterpolation } from '@remirror/core-types';
 import { useRemirrorTheme } from '@remirror/ui';
-import { Fragment, forwardRef, useMemo } from 'react';
+import { forwardRef, Fragment, useMemo } from 'react';
 
 export interface IconProps {
   /**

--- a/@remirror/ui-icons/src/base/angle-down-icon.tsx
+++ b/@remirror/ui-icons/src/base/angle-down-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const AngleDownIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/base/angle-left-icon.tsx
+++ b/@remirror/ui-icons/src/base/angle-left-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const AngleLeftIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/base/angle-right-icon.tsx
+++ b/@remirror/ui-icons/src/base/angle-right-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const AngleRightIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/base/angle-up-icon.tsx
+++ b/@remirror/ui-icons/src/base/angle-up-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const AngleUpIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/__tests__/editor-icons.spec.tsx
+++ b/@remirror/ui-icons/src/editor/__tests__/editor-icons.spec.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
+
 import * as EditorIcons from '../';
 
 test('editor icon snapshots', () => {

--- a/@remirror/ui-icons/src/editor/align-center-icon.tsx
+++ b/@remirror/ui-icons/src/editor/align-center-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const AlignCenterIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/align-justify-icon.tsx
+++ b/@remirror/ui-icons/src/editor/align-justify-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const AlignJustifyIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/align-left-icon.tsx
+++ b/@remirror/ui-icons/src/editor/align-left-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const AlignLeftIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/align-right-icon.tsx
+++ b/@remirror/ui-icons/src/editor/align-right-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const AlignRightIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/bold-icon.tsx
+++ b/@remirror/ui-icons/src/editor/bold-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const BoldIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/border-all-icon.tsx
+++ b/@remirror/ui-icons/src/editor/border-all-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const BorderAllIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/border-none-icon.tsx
+++ b/@remirror/ui-icons/src/editor/border-none-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const BorderNoneIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/border-style-icon.tsx
+++ b/@remirror/ui-icons/src/editor/border-style-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const BorderStyleIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/clipboard-icon.tsx
+++ b/@remirror/ui-icons/src/editor/clipboard-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const ClipboardIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/clone-icon.tsx
+++ b/@remirror/ui-icons/src/editor/clone-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const CloneIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/code-icon.tsx
+++ b/@remirror/ui-icons/src/editor/code-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const CodeIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/columns-icon.tsx
+++ b/@remirror/ui-icons/src/editor/columns-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const ColumnsIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/copy-icon.tsx
+++ b/@remirror/ui-icons/src/editor/copy-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const CopyIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/cut-icon.tsx
+++ b/@remirror/ui-icons/src/editor/cut-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const CutIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/edit-icon.tsx
+++ b/@remirror/ui-icons/src/editor/edit-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const EditIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/eraser-icon.tsx
+++ b/@remirror/ui-icons/src/editor/eraser-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const EraserIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/file-alt-icon.tsx
+++ b/@remirror/ui-icons/src/editor/file-alt-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const FileAltIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/file-icon.tsx
+++ b/@remirror/ui-icons/src/editor/file-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const FileIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/filter-icon.tsx
+++ b/@remirror/ui-icons/src/editor/filter-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const FilterIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/font-icon.tsx
+++ b/@remirror/ui-icons/src/editor/font-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const FontIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/glasses-icon.tsx
+++ b/@remirror/ui-icons/src/editor/glasses-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const GlassesIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/h1-icon.tsx
+++ b/@remirror/ui-icons/src/editor/h1-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const H1Icon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/h2-icon.tsx
+++ b/@remirror/ui-icons/src/editor/h2-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const H2Icon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/h3-icon.tsx
+++ b/@remirror/ui-icons/src/editor/h3-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const H3Icon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/h4-icon.tsx
+++ b/@remirror/ui-icons/src/editor/h4-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const H4Icon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/h5-icon.tsx
+++ b/@remirror/ui-icons/src/editor/h5-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const H5Icon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/h6-icon.tsx
+++ b/@remirror/ui-icons/src/editor/h6-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const H6Icon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/heading-icon.tsx
+++ b/@remirror/ui-icons/src/editor/heading-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const HeadingIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/highlighter-icon.tsx
+++ b/@remirror/ui-icons/src/editor/highlighter-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const HighlighterIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/i-cursor-icon.tsx
+++ b/@remirror/ui-icons/src/editor/i-cursor-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const ICursorIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/icons-icon.tsx
+++ b/@remirror/ui-icons/src/editor/icons-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const IconsIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/images-regular-icon.tsx
+++ b/@remirror/ui-icons/src/editor/images-regular-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const ImagesRegularIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/images-solid-icon.tsx
+++ b/@remirror/ui-icons/src/editor/images-solid-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const ImagesSolidIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/indent-icon.tsx
+++ b/@remirror/ui-icons/src/editor/indent-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const IndentIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/italic-icon.tsx
+++ b/@remirror/ui-icons/src/editor/italic-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const ItalicIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/link-icon.tsx
+++ b/@remirror/ui-icons/src/editor/link-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const LinkIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/list-alt-icon.tsx
+++ b/@remirror/ui-icons/src/editor/list-alt-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const ListAltIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/list-icon.tsx
+++ b/@remirror/ui-icons/src/editor/list-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const ListIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/list-ol-icon.tsx
+++ b/@remirror/ui-icons/src/editor/list-ol-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const ListOlIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/list-ul-icon.tsx
+++ b/@remirror/ui-icons/src/editor/list-ul-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const ListUlIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/marker-icon.tsx
+++ b/@remirror/ui-icons/src/editor/marker-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const MarkerIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/outdent-icon.tsx
+++ b/@remirror/ui-icons/src/editor/outdent-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const OutdentIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/paper-plane-icon.tsx
+++ b/@remirror/ui-icons/src/editor/paper-plane-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const PaperPlaneIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/paperclip-icon.tsx
+++ b/@remirror/ui-icons/src/editor/paperclip-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const PaperclipIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/paragraph-icon.tsx
+++ b/@remirror/ui-icons/src/editor/paragraph-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const ParagraphIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/paste-icon.tsx
+++ b/@remirror/ui-icons/src/editor/paste-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const PasteIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/pen-alt-icon.tsx
+++ b/@remirror/ui-icons/src/editor/pen-alt-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const PenAltIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/pen-fancy-icon.tsx
+++ b/@remirror/ui-icons/src/editor/pen-fancy-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const PenFancyIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/pen-icon.tsx
+++ b/@remirror/ui-icons/src/editor/pen-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const PenIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/pen-nib-icon.tsx
+++ b/@remirror/ui-icons/src/editor/pen-nib-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const PenNibIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/pencil-alt-icon.tsx
+++ b/@remirror/ui-icons/src/editor/pencil-alt-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const PencilAltIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/print-icon.tsx
+++ b/@remirror/ui-icons/src/editor/print-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const PrintIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/quote-left-icon.tsx
+++ b/@remirror/ui-icons/src/editor/quote-left-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const QuoteLeftIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/quote-right-icon.tsx
+++ b/@remirror/ui-icons/src/editor/quote-right-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const QuoteRightIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/redo-alt-icon.tsx
+++ b/@remirror/ui-icons/src/editor/redo-alt-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const RedoAltIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/redo-icon.tsx
+++ b/@remirror/ui-icons/src/editor/redo-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const RedoIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/remove-format-icon.tsx
+++ b/@remirror/ui-icons/src/editor/remove-format-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const RemoveFormatIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/reply-all-icon.tsx
+++ b/@remirror/ui-icons/src/editor/reply-all-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const ReplyAllIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/reply-icon.tsx
+++ b/@remirror/ui-icons/src/editor/reply-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const ReplyIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/ruler-horizontal-icon.tsx
+++ b/@remirror/ui-icons/src/editor/ruler-horizontal-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const RulerHorizontalIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/screwdriver-icon.tsx
+++ b/@remirror/ui-icons/src/editor/screwdriver-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const ScrewdriverIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/share-icon.tsx
+++ b/@remirror/ui-icons/src/editor/share-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const ShareIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/spell-check-icon.tsx
+++ b/@remirror/ui-icons/src/editor/spell-check-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const SpellCheckIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/strikethrough-icon.tsx
+++ b/@remirror/ui-icons/src/editor/strikethrough-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const StrikethroughIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/subscript-icon.tsx
+++ b/@remirror/ui-icons/src/editor/subscript-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const SubscriptIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/superscript-icon.tsx
+++ b/@remirror/ui-icons/src/editor/superscript-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const SuperscriptIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/sync-alt-icon.tsx
+++ b/@remirror/ui-icons/src/editor/sync-alt-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const SyncAltIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/sync-icon.tsx
+++ b/@remirror/ui-icons/src/editor/sync-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const SyncIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/table-icon.tsx
+++ b/@remirror/ui-icons/src/editor/table-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const TableIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/tasks-icon.tsx
+++ b/@remirror/ui-icons/src/editor/tasks-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const TasksIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/text-height-icon.tsx
+++ b/@remirror/ui-icons/src/editor/text-height-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const TextHeightIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/text-width-icon.tsx
+++ b/@remirror/ui-icons/src/editor/text-width-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const TextWidthIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/th-icon.tsx
+++ b/@remirror/ui-icons/src/editor/th-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const ThIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/th-large-icon.tsx
+++ b/@remirror/ui-icons/src/editor/th-large-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const ThLargeIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/th-list-icon.tsx
+++ b/@remirror/ui-icons/src/editor/th-list-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const ThListIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/times-icon.tsx
+++ b/@remirror/ui-icons/src/editor/times-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const TimesIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/tools-icon.tsx
+++ b/@remirror/ui-icons/src/editor/tools-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const ToolsIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/trash-alt-icon.tsx
+++ b/@remirror/ui-icons/src/editor/trash-alt-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const TrashAltIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/trash-icon.tsx
+++ b/@remirror/ui-icons/src/editor/trash-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const TrashIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/trash-restore-alt-icon.tsx
+++ b/@remirror/ui-icons/src/editor/trash-restore-alt-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const TrashRestoreAltIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/trash-restore-icon.tsx
+++ b/@remirror/ui-icons/src/editor/trash-restore-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const TrashRestoreIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/underline-icon.tsx
+++ b/@remirror/ui-icons/src/editor/underline-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const UnderlineIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/undo-alt-icon.tsx
+++ b/@remirror/ui-icons/src/editor/undo-alt-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const UndoAltIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/undo-icon.tsx
+++ b/@remirror/ui-icons/src/editor/undo-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const UndoIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/unlink-icon.tsx
+++ b/@remirror/ui-icons/src/editor/unlink-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const UnlinkIcon = (props: IconProps) => (

--- a/@remirror/ui-icons/src/editor/wrench-icon.tsx
+++ b/@remirror/ui-icons/src/editor/wrench-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Icon, IconProps } from '../base-icon';
 
 export const WrenchIcon = (props: IconProps) => (

--- a/@remirror/ui-menus/src/__stories__/menus.stories.tsx
+++ b/@remirror/ui-menus/src/__stories__/menus.stories.tsx
@@ -1,9 +1,10 @@
 import { DropdownItem } from '@remirror/ui-dropdown';
 import { ImagesRegularIcon } from '@remirror/ui-icons/lib/editor/images-regular-icon';
-import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
+import { storiesOf } from '@storybook/react';
 import React from 'react';
 import useState from 'react-use/lib/useSetState';
+
 import { Menubar } from '..';
 import { MenubarContent } from '../menu-bar';
 

--- a/@remirror/ui-menus/src/menu-bar.tsx
+++ b/@remirror/ui-menus/src/menu-bar.tsx
@@ -4,7 +4,7 @@ import { isPlainObject } from '@remirror/core-helpers';
 import { useRemirrorTheme } from '@remirror/ui';
 import { Button, ButtonProps } from '@remirror/ui-buttons';
 import { DropdownProps, DropdownSelect } from '@remirror/ui-dropdown';
-import { FC, Fragment, forwardRef, ReactElement } from 'react';
+import { FC, forwardRef, Fragment, ReactElement } from 'react';
 
 interface MenubarDropdownConfiguration extends DropdownProps {
   type: 'dropdown';

--- a/@remirror/ui-text/src/__stories__/text.stories.tsx
+++ b/@remirror/ui-text/src/__stories__/text.stories.tsx
@@ -3,6 +3,7 @@ import { jsx } from '@emotion/core';
 import { useRemirrorTheme } from '@remirror/ui';
 import { storiesOf } from '@storybook/react';
 import { FC } from 'react';
+
 import { Caption, H1, H2, H3, H4, H5, H6, Label, Text } from '../';
 
 const Grid: FC = ({ children }) => {

--- a/@remirror/ui-text/src/ui-text.tsx
+++ b/@remirror/ui-text/src/ui-text.tsx
@@ -1,7 +1,6 @@
 /** @jsx jsx */
 
-import { jsx, Interpolation } from '@emotion/core';
-
+import { Interpolation, jsx } from '@emotion/core';
 import { omit, pick } from '@remirror/core-helpers';
 import { KeyOfThemeVariant } from '@remirror/core-types';
 import { useRemirrorTheme } from '@remirror/ui';

--- a/@remirror/ui/src/__tests__/ui-hsl.spec.ts
+++ b/@remirror/ui/src/__tests__/ui-hsl.spec.ts
@@ -1,4 +1,5 @@
 import { pick } from '@remirror/core-helpers';
+
 import { HSL, HSLObject, NamedHSLObject, ValidHSLObject, ValidHSLTuple } from '../ui-hsl';
 
 const validInputString: Array<[string, ValidHSLObject, ValidHSLTuple, string]> = [

--- a/@remirror/ui/src/__tests__/ui-provider-ssr.spec.tsx
+++ b/@remirror/ui/src/__tests__/ui-provider-ssr.spec.tsx
@@ -6,6 +6,7 @@ import { Remirror } from '@remirror/react';
 import { createTestManager } from '@remirror/test-fixtures';
 import React from 'react';
 import { renderToString } from 'react-dom/server';
+
 import { baseTheme, RemirrorThemeProvider } from '..';
 
 describe('withoutEmotion', () => {

--- a/@remirror/ui/src/__tests__/ui-provider.spec.tsx
+++ b/@remirror/ui/src/__tests__/ui-provider.spec.tsx
@@ -3,6 +3,7 @@ import { createTestManager } from '@remirror/test-fixtures';
 import { render } from '@testing-library/react';
 import { ThemeProvider } from 'emotion-theming';
 import React from 'react';
+
 import { baseTheme } from '..';
 import { useEmotionTheme, useRemirrorTheme } from '../ui-hooks';
 import { RemirrorThemeProvider } from '../ui-provider';

--- a/@remirror/ui/src/__tests__/ui-utils.spec.tsx
+++ b/@remirror/ui/src/__tests__/ui-utils.spec.tsx
@@ -1,6 +1,7 @@
 /** @jsx jsx */
-import { jsx, css as emotionCss } from '@emotion/core';
+import { css as emotionCss, jsx } from '@emotion/core';
 import { render } from '@testing-library/react';
+
 import { baseTheme } from '../';
 import { RemirrorThemeProvider } from '../ui-provider';
 import { cssValueUnits, numberToPixels, sx } from '../ui-utils';

--- a/@remirror/ui/src/ui-context.tsx
+++ b/@remirror/ui/src/ui-context.tsx
@@ -1,6 +1,7 @@
 import { css, ThemeContext } from '@emotion/core';
 import { RemirrorTheme, RemirrorThemeContextType } from '@remirror/core-types';
 import { Context, createContext } from 'react';
+
 import { baseTheme } from './ui-theme';
 import { getColorModes, getFactory, sx } from './ui-utils';
 

--- a/@remirror/ui/src/ui-hooks.ts
+++ b/@remirror/ui/src/ui-hooks.ts
@@ -1,5 +1,6 @@
 import { RemirrorTheme, RemirrorThemeContextType } from '@remirror/core-types';
 import { useContext } from 'react';
+
 import { EmotionThemeContext, RemirrorThemeContext } from './ui-context';
 /**
  * A hook for pulling the remirror theme from the react context.

--- a/@remirror/ui/src/ui-provider.tsx
+++ b/@remirror/ui/src/ui-provider.tsx
@@ -5,6 +5,7 @@ import { bool, deepMerge, isFunction } from '@remirror/core-helpers';
 import { RemirrorTheme, RemirrorThemeContextType } from '@remirror/core-types';
 import { ThemeProvider as EmotionThemeProvider } from 'emotion-theming';
 import { FC, ReactElement, useMemo, useState } from 'react';
+
 import { defaultRemirrorThemeValue, RemirrorThemeContext, withoutEmotionProps } from './ui-context';
 import { useEmotionTheme, useRemirrorTheme } from './ui-hooks';
 import { applyColorMode, getColorModes, getFactory } from './ui-utils';

--- a/@remirror/ui/src/ui-theme-root.tsx
+++ b/@remirror/ui/src/ui-theme-root.tsx
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import { Global, jsx } from '@emotion/core';
 import { FC } from 'react';
+
 import { useRemirrorTheme } from './ui-hooks';
 
 export interface RemirrorThemeRootProps {

--- a/@remirror/ui/src/ui-theme.ts
+++ b/@remirror/ui/src/ui-theme.ts
@@ -1,5 +1,6 @@
 import { EDITOR_CLASS_SELECTOR } from '@remirror/core-constants';
 import { RemirrorTheme } from '@remirror/core-types';
+
 import { HSL } from './ui-hsl';
 
 const baseHue = 205;
@@ -120,12 +121,12 @@ export const baseTheme: RemirrorTheme = {
     focus: 'hsla(205, 73%, 57%, 0.6) 0px 0px 0px 3px',
     buttons: '0 0 0 0 hsla(205, 6%, 14%, 0.15) inset',
     text: 'none',
-    card: `${HSL.create([baseHue, baseSaturation, 15, 25])} 0 4px 8px -2px, ${HSL.create([
+    card: `${HSL.create([baseHue, baseSaturation, 15, 25]).toString()} 0 4px 8px -2px, ${HSL.create([
       baseHue,
       baseSaturation,
       15,
       31,
-    ])} 0px 0px 1px`,
+    ]).toString()} 0px 0px 1px`,
   },
 
   'remirror:buttons': {

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,12 @@ and this project will adhere to [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Removed
+
+- `@remirror/core`: Remove deprecated `findNodeAtEndOfDoc`
+  `findNodeAtStartOfDoc` which can be replaced with `doc.firstChild` and
+  `doc.lastChild`
+
 ## [0.7.2] - 2019-12-10
 
 ### Changes

--- a/docs/src/components/footer.tsx
+++ b/docs/src/components/footer.tsx
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 
 import { Container, Footer as FooterUI, jsx } from 'theme-ui';
+
 import NavLink from './nav-link';
 
 export const Footer = () => (

--- a/docs/src/components/head.tsx
+++ b/docs/src/components/head.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 import { Helmet } from 'react-helmet';
+
 import pkg from '../../package.json';
 import { RootLayoutProps } from '../typings';
 

--- a/docs/src/components/header.tsx
+++ b/docs/src/components/header.tsx
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import { Dispatch, RefObject, SetStateAction } from 'react';
 import { Container, Flex, Header as HeaderUI, jsx, useColorMode } from 'theme-ui';
+
 import Button from './button';
 import MenuButton from './menu-button';
 import NavLink from './nav-link';

--- a/docs/src/components/logo.tsx
+++ b/docs/src/components/logo.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import theme from '../gatsby-plugin-theme-ui';
 
 type SvgProps = JSX.IntrinsicElements['svg'];

--- a/docs/src/components/menu-button.tsx
+++ b/docs/src/components/menu-button.tsx
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui';
+
 import { ButtonProps } from './button';
 
 const Burger = ({ size = '1em' }) => (

--- a/docs/src/components/pagination.tsx
+++ b/docs/src/components/pagination.tsx
@@ -2,6 +2,7 @@
 import { Location } from '@reach/router';
 import { Pagination as PaginationUI } from '@theme-ui/sidenav';
 import { jsx } from 'theme-ui';
+
 import Sidenav from '../sidebar.mdx';
 
 export const Pagination = () => (

--- a/docs/src/components/sidebar.tsx
+++ b/docs/src/components/sidebar.tsx
@@ -2,6 +2,7 @@
 import { Sidenav, SidnavProps } from '@theme-ui/sidenav';
 import React from 'react';
 import { jsx } from 'theme-ui';
+
 import Content from '../sidebar.mdx';
 import NavLink from './nav-link';
 

--- a/docs/src/gatsby-plugin-theme-ui/components.tsx
+++ b/docs/src/gatsby-plugin-theme-ui/components.tsx
@@ -1,10 +1,10 @@
 /** @jsx jsx */
 
+import { capitalize } from '@remirror/core-helpers';
 import CodeBlock from '@theme-ui/prism';
 import { ElementType, FC } from 'react';
-import { jsx } from 'theme-ui';
 import { isString } from 'remirror';
-import { capitalize } from '@remirror/core-helpers';
+import { jsx } from 'theme-ui';
 
 const heading = (Tag: ElementType) => {
   const Component: FC<{ id: string }> = props =>

--- a/docs/src/layouts/layout.tsx
+++ b/docs/src/layouts/layout.tsx
@@ -3,6 +3,7 @@
 import { Global } from '@emotion/core';
 import { FC, useRef, useState } from 'react';
 import { Container, jsx, Layout as LayoutUI, Main, Styled } from 'theme-ui';
+
 import EditLink from '../components/edit-link';
 import Footer from '../components/footer';
 import Head from '../components/head';

--- a/e2e/jest.puppeteer.setup.ts
+++ b/e2e/jest.puppeteer.setup.ts
@@ -1,4 +1,5 @@
 import { Config } from '@jest/types';
+
 import { startServer } from './puppeteer';
 
 export default async (globalConfig: Config.GlobalConfig) => {

--- a/e2e/jest.puppeteer.teardown.ts
+++ b/e2e/jest.puppeteer.teardown.ts
@@ -1,4 +1,5 @@
 import { Config } from '@jest/types';
+
 import { destroyServer } from './puppeteer';
 
 export default async (globalConfig: Config.GlobalConfig) => {

--- a/e2e/src/helpers/images.ts
+++ b/e2e/src/helpers/images.ts
@@ -1,9 +1,9 @@
-import looksSame, { createDiff } from 'looks-same';
 import { kebabCase } from '@remirror/core';
-import { promisify } from 'util';
-import { resolve, dirname } from 'path';
 import { writeFile } from 'fs';
+import looksSame, { createDiff } from 'looks-same';
 import md from 'mkdirp-promise';
+import { dirname, resolve } from 'path';
+import { promisify } from 'util';
 
 const write = promisify(writeFile);
 

--- a/e2e/src/helpers/index.ts
+++ b/e2e/src/helpers/index.ts
@@ -1,5 +1,6 @@
 import { MakeOptional } from '@remirror/core';
 import { SupportedCharacters } from 'test-keyboard';
+
 import { getBrowserName } from './test-environment';
 
 /**

--- a/e2e/src/social.e2e.test.ts
+++ b/e2e/src/social.e2e.test.ts
@@ -1,6 +1,7 @@
 import { EDITOR_CLASS_SELECTOR } from '@remirror/core';
 import { getDocument, queries } from 'pptr-testing-library';
 import { ElementHandle } from 'puppeteer';
+
 import {
   $innerHTML,
   innerHtml,

--- a/e2e/src/wysiwyg.e2e.test.ts
+++ b/e2e/src/wysiwyg.e2e.test.ts
@@ -1,5 +1,6 @@
 import { getDocument, queries } from 'pptr-testing-library';
 import { ElementHandle } from 'puppeteer';
+
 import { mod, press, pressKeyWithModifier, selectAll, textContent } from './helpers';
 
 const { getByRole } = queries;

--- a/examples/with-next/components/layout.tsx
+++ b/examples/with-next/components/layout.tsx
@@ -1,7 +1,6 @@
-import React, { FunctionComponent } from 'react';
-
 import Head from 'next/head';
 import Link from 'next/link';
+import React, { FunctionComponent } from 'react';
 
 interface Props {
   title?: string;

--- a/examples/with-next/components/list-item.tsx
+++ b/examples/with-next/components/list-item.tsx
@@ -1,6 +1,6 @@
+import Link from 'next/link';
 import React, { FunctionComponent } from 'react';
 
-import Link from 'next/link';
 import { User } from '../interfaces';
 
 interface Props {

--- a/examples/with-next/components/list.tsx
+++ b/examples/with-next/components/list.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from 'react';
+
 import { User } from '../interfaces';
 import ListItem from './list-item';
 

--- a/examples/with-next/pages/_app.tsx
+++ b/examples/with-next/pages/_app.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import { css, Global } from '@emotion/core';
 import App from 'next/app';
-import { Global, css } from '@emotion/core';
+import React from 'react';
 
 export default class MyApp extends App {
   // Only uncomment this method if you have blocking data requirements for

--- a/examples/with-next/pages/detail.tsx
+++ b/examples/with-next/pages/detail.tsx
@@ -1,5 +1,6 @@
 import { NextPageContext } from 'next';
 import React, { Component } from 'react';
+
 import Layout from '../components/layout';
 import ListDetail from '../components/list-detail';
 import { User } from '../interfaces';

--- a/examples/with-next/pages/index.tsx
+++ b/examples/with-next/pages/index.tsx
@@ -1,6 +1,7 @@
 import { NextPage } from 'next';
 import Link from 'next/link';
 import * as React from 'react';
+
 import Layout from '../components/layout';
 
 const IndexPage: NextPage = () => {

--- a/examples/with-next/pages/initial-props.tsx
+++ b/examples/with-next/pages/initial-props.tsx
@@ -1,6 +1,7 @@
 import { NextPage } from 'next';
 import Link from 'next/link';
 import React from 'react';
+
 import Layout from '../components/layout';
 import List from '../components/list';
 import { User } from '../interfaces';

--- a/examples/with-razzle/src/app.tsx
+++ b/examples/with-razzle/src/app.tsx
@@ -1,6 +1,7 @@
 import { css, Global } from '@emotion/core';
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
+
 import { SocialEditor, SocialEditorWithContent } from './editors/social';
 import { WysiwygEditor, WysiwygEditorWithContent } from './editors/wysiwyg';
 import Home from './home';

--- a/examples/with-razzle/src/home.tsx
+++ b/examples/with-razzle/src/home.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import React from 'react';
+
 import logo from './logo.svg';
 
 class Home extends React.Component {

--- a/examples/with-razzle/src/server.tsx
+++ b/examples/with-razzle/src/server.tsx
@@ -2,6 +2,7 @@ import express from 'express';
 import React from 'react';
 import { renderToString } from 'react-dom/server';
 import { StaticRouter } from 'react-router-dom';
+
 import App from './app';
 
 declare global {
@@ -38,11 +39,11 @@ const server = express()
         <meta charSet='utf-8' />
         <title>Razzle TypeScript</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        ${assets.client.css ? `<link rel="stylesheet" href="${assets.client.css}">` : ''}
+        ${assets.client.css ? `<link rel="stylesheet" href="${assets.client.css as string}">` : ''}
           ${
             process.env.NODE_ENV === 'production'
-              ? `<script src="${assets.client.js}" defer></script>`
-              : `<script src="${assets.client.js}" defer crossorigin></script>`
+              ? `<script src="${assets.client.js as string}" defer></script>`
+              : `<script src="${assets.client.js as string}" defer crossorigin></script>`
           }
     </head>
     <body>

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-react": "^7.16.0",
     "eslint-plugin-react-hooks": "^2.1.2",
+    "eslint-plugin-simple-import-sort": "^5.0.0",
     "eslint-plugin-unicorn": "^14.0.1",
     "husky": "^3.1.0",
     "jest": "^24.9.0",

--- a/packages/jest-prosemirror/src/__tests__/jest-prosemirror.spec.ts
+++ b/packages/jest-prosemirror/src/__tests__/jest-prosemirror.spec.ts
@@ -1,4 +1,4 @@
-import { p, doc, prosemirrorSerializer, schema } from '../';
+import { doc, p, prosemirrorSerializer, schema } from '../';
 import { createEditor } from '../jest-prosemirror-editor';
 
 test('serializer', () => {

--- a/packages/jest-prosemirror/src/jest-prosemirror-editor.ts
+++ b/packages/jest-prosemirror/src/jest-prosemirror-editor.ts
@@ -1,5 +1,4 @@
-import { findElementAtPosition, isElementDOMNode, isTextDOMNode } from '@remirror/core-utils';
-import { pick, isString } from '@remirror/core-helpers';
+import { isString, pick } from '@remirror/core-helpers';
 import {
   CommandFunction,
   EditorSchema,
@@ -8,18 +7,20 @@ import {
   PlainObject,
   Plugin,
   PosParams,
+  ProsemirrorNode,
   SelectionParams,
   TextParams,
-  ProsemirrorNode,
 } from '@remirror/core-types';
+import { findElementAtPosition, isElementDOMNode, isTextDOMNode } from '@remirror/core-utils';
 import { fireEvent, prettyDOM } from '@testing-library/dom';
 import { inputRules } from 'prosemirror-inputrules';
 import { AllSelection, NodeSelection, TextSelection } from 'prosemirror-state';
 import { TaggedProsemirrorNode } from 'prosemirror-test-builder';
 import { DirectEditorProps, EditorView } from 'prosemirror-view';
 import { Keyboard } from 'test-keyboard';
+
 import { createEvents, EventType } from './jest-prosemirror-events';
-import { createState, pm, selectionFor, taggedDocHasSelection, p } from './jest-prosemirror-nodes';
+import { createState, p, pm, selectionFor, taggedDocHasSelection } from './jest-prosemirror-nodes';
 import { TaggedDocParams, TestEditorView, TestEditorViewParams } from './jest-prosemirror-types';
 
 /**

--- a/packages/jest-prosemirror/src/jest-prosemirror-matchers.ts
+++ b/packages/jest-prosemirror/src/jest-prosemirror-matchers.ts
@@ -1,6 +1,7 @@
-import { CommandFunction, ProsemirrorNode as _ProsemirrorNode } from '@remirror/core-types';
 import { bool } from '@remirror/core-helpers';
+import { CommandFunction, ProsemirrorNode as _ProsemirrorNode } from '@remirror/core-types';
 import { TaggedProsemirrorNode } from 'prosemirror-test-builder';
+
 import { apply } from './jest-prosemirror-editor';
 import { transformsNodeFailMessage, transformsNodePassMessage } from './jest-prosemirror-messages';
 import { CommandTransformation } from './jest-prosemirror-types';

--- a/packages/jest-prosemirror/src/jest-prosemirror-messages.ts
+++ b/packages/jest-prosemirror/src/jest-prosemirror-messages.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
 import { TaggedProsemirrorNode } from 'prosemirror-test-builder';
+
 import { selectionFor } from './jest-prosemirror-nodes';
 
 export const transformsNodePassMessage = (

--- a/packages/jest-prosemirror/src/jest-prosemirror-nodes.ts
+++ b/packages/jest-prosemirror/src/jest-prosemirror-nodes.ts
@@ -5,6 +5,7 @@ import { Schema } from 'prosemirror-model';
 import { AllSelection, EditorState, NodeSelection, Selection, TextSelection } from 'prosemirror-state';
 import { cellAround, CellSelection } from 'prosemirror-tables';
 import pm, { MarkTypeAttributes, NodeTypeAttributes, TaggedProsemirrorNode } from 'prosemirror-test-builder';
+
 import { schema } from './jest-prosemirror-schema';
 import { TaggedDocParams } from './jest-prosemirror-types';
 

--- a/packages/jest-prosemirror/src/jest-prosemirror-serializer.ts
+++ b/packages/jest-prosemirror/src/jest-prosemirror-serializer.ts
@@ -1,5 +1,5 @@
 import { keys } from '@remirror/core-helpers';
-import { isProsemirrorNode, isEditorState, isEditorSchema } from '@remirror/core-utils';
+import { isEditorSchema, isEditorState, isProsemirrorNode } from '@remirror/core-utils';
 
 /**
  * Jest serializer for prosemirror nodes and the editor state.

--- a/packages/jest-remirror/src/__tests__/jest-remirror-builder.spec.ts
+++ b/packages/jest-remirror/src/__tests__/jest-remirror-builder.spec.ts
@@ -1,5 +1,6 @@
 import { clone } from '@remirror/core';
 import { schema } from '@remirror/test-fixtures';
+
 import { markFactory, nodeFactory, sequence, text } from '../jest-remirror-builder';
 import { TagTracker } from '../jest-remirror-types';
 

--- a/packages/jest-remirror/src/__tests__/jest-remirror-editor.spec.ts
+++ b/packages/jest-remirror/src/__tests__/jest-remirror-editor.spec.ts
@@ -7,6 +7,7 @@ import {
 } from '@remirror/core-extensions';
 import { cleanup } from '@testing-library/react';
 import { Plugin } from 'prosemirror-state';
+
 import { renderEditor } from '../jest-remirror-editor';
 
 beforeEach(cleanup);

--- a/packages/jest-remirror/src/__tests__/jest-remirror-matchers.spec.ts
+++ b/packages/jest-remirror/src/__tests__/jest-remirror-matchers.spec.ts
@@ -1,5 +1,6 @@
 import { Cast } from '@remirror/core';
 import { BoldExtension } from '@remirror/core-extensions';
+
 import { renderEditor } from '../jest-remirror-editor';
 
 describe('toContainRemirrorDocument', () => {

--- a/packages/jest-remirror/src/__tests__/jsdom-patch.spec.ts
+++ b/packages/jest-remirror/src/__tests__/jsdom-patch.spec.ts
@@ -1,5 +1,6 @@
 import { Cast } from '@remirror/core';
 import { EditorView } from 'prosemirror-view';
+
 import { jsdomSelectionPatch, NullSelectionReader } from '../jsdom-patch';
 import { jsdomPolyfill } from '../jsdom-polyfills';
 

--- a/packages/jest-remirror/src/jest-remirror-builder.ts
+++ b/packages/jest-remirror/src/jest-remirror-builder.ts
@@ -2,13 +2,14 @@ import {
   EditorSchema,
   findMatches,
   flattenArray,
+  hasOwnProperty,
   isInstanceOf,
   isProsemirrorNode,
   isString,
   SchemaParams,
-  hasOwnProperty,
 } from '@remirror/core';
 import { Fragment, Mark, Node as PMNode, Slice } from 'prosemirror-model';
+
 import {
   BaseFactoryParams,
   TaggedContent,

--- a/packages/jest-remirror/src/jest-remirror-editor.tsx
+++ b/packages/jest-remirror/src/jest-remirror-editor.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import {
   Attrs,
   Cast,
@@ -19,14 +17,15 @@ import {
   dispatchTextSelection,
   fireEventAtPosition,
   insertText,
+  pasteContent,
   press,
   shortcut,
-  pasteContent,
   TestEditorView,
 } from 'jest-prosemirror';
+import React from 'react';
+
 import { markFactory, nodeFactory } from './jest-remirror-builder';
 import { BaseExtensionNodeNames, nodeExtensions } from './jest-remirror-schema';
-import { replaceSelection } from './jest-remirror-utils';
 import {
   AddContent,
   AddContentReturn,
@@ -40,6 +39,7 @@ import {
   NodeWithoutAttrs,
   Tags,
 } from './jest-remirror-types';
+import { replaceSelection } from './jest-remirror-utils';
 import { jsdomSelectionPatch } from './jsdom-patch';
 
 /**

--- a/packages/jest-remirror/src/jest-remirror-matchers.ts
+++ b/packages/jest-remirror/src/jest-remirror-matchers.ts
@@ -1,4 +1,5 @@
 import { EditorState, isEditorState, isProsemirrorNode, ProsemirrorNode } from '@remirror/core';
+
 import { TaggedProsemirrorNode } from './jest-remirror-types';
 
 export const remirrorMatchers: jest.ExpectExtendMap = {

--- a/packages/jest-remirror/src/jest-remirror-ssr.tsx
+++ b/packages/jest-remirror/src/jest-remirror-ssr.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-
 import { AnyExtension, ExtensionManager } from '@remirror/core';
 import { Remirror, RemirrorProps } from '@remirror/react';
+import React from 'react';
 import { renderToString } from 'react-dom/server';
+
 import { nodeExtensions } from './jest-remirror-schema';
 
 /**

--- a/packages/jest-remirror/src/jest-remirror-types.ts
+++ b/packages/jest-remirror/src/jest-remirror-types.ts
@@ -4,21 +4,22 @@ import {
   Attrs,
   AttrsParams,
   CommandFunction,
+  EditorSchema,
   EditorState,
   EditorStateParams,
+  EditorViewParams,
   Extension,
   HelpersFromExtensions,
   MarkExtension,
   NodeExtension,
   ProsemirrorNode,
   SchemaFromExtensions,
-  EditorViewParams,
-  EditorSchema,
 } from '@remirror/core';
 import { InjectedRemirrorProps } from '@remirror/react';
 import { RenderResult } from '@testing-library/react/pure';
 import { FireParams, TestEditorViewParams } from 'jest-prosemirror';
 import { Node as PMNode } from 'prosemirror-model';
+
 import { BaseExtensionNodeNames, BaseExtensionNodes } from './jest-remirror-schema';
 
 export interface BaseFactoryParams<GSchema extends EditorSchema = EditorSchema> extends Partial<AttrsParams> {

--- a/packages/jest-remirror/src/jest-remirror-utils.ts
+++ b/packages/jest-remirror/src/jest-remirror-utils.ts
@@ -1,5 +1,6 @@
-import { SchemaParams, isProsemirrorNode, isObject } from '@remirror/core';
+import { isObject, isProsemirrorNode, SchemaParams } from '@remirror/core';
 import { TestEditorViewParams } from 'jest-prosemirror';
+
 import { coerce, offsetTags } from './jest-remirror-builder';
 import { TaggedProsemirrorNode, Tags } from './jest-remirror-types';
 

--- a/packages/multishift/src/__stories__/multishift.stories.tsx
+++ b/packages/multishift/src/__stories__/multishift.stories.tsx
@@ -1,5 +1,6 @@
 import { storiesOf } from '@storybook/react';
 import React, { useState } from 'react';
+
 import { useMultishift } from '../multishift';
 
 const names = ['Olu', 'Tolu', 'Bemi', 'Jay', 'Raj', 'Li Peng', 'Ryoku', 'Temi', 'Kima'];

--- a/packages/multishift/src/__tests__/multishift-nested.spec.tsx
+++ b/packages/multishift/src/__tests__/multishift-nested.spec.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
+
 import { useMultishift } from '../multishift';
 
 const Component = ({ multiple }: { multiple: boolean }) => {

--- a/packages/multishift/src/__tests__/multishift.spec.tsx
+++ b/packages/multishift/src/__tests__/multishift.spec.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
+
 import { useMultishift } from '../multishift';
 
 const Component = ({ multiple }: { multiple: boolean }) => {

--- a/packages/multishift/src/multishift-hooks.ts
+++ b/packages/multishift/src/multishift-hooks.ts
@@ -1,8 +1,9 @@
 import { useId } from '@reach/auto-id';
 import { useEffectOnce, useEffectOnUpdate } from '@remirror/react-hooks';
-import { useEffect, useReducer, useRef } from 'react';
-import { multishiftReducer } from './multishift-reducer';
 import { setStatus } from '@remirror/ui-a11y-status';
+import { useEffect, useReducer, useRef } from 'react';
+
+import { multishiftReducer } from './multishift-reducer';
 import {
   A11yStatusMessageParams,
   GetA11yStatusMessage,

--- a/packages/multishift/src/multishift-types.ts
+++ b/packages/multishift/src/multishift-types.ts
@@ -10,6 +10,7 @@ import {
   MouseEvent,
   Ref,
 } from 'react';
+
 import { DropdownType, SpecialKey } from './multishift-constants';
 
 export interface MultishiftState<GItem = any> {

--- a/packages/multishift/src/multishift-utils.ts
+++ b/packages/multishift/src/multishift-utils.ts
@@ -18,6 +18,7 @@ import { AnyFunction, Nullable } from '@remirror/core-types';
 import computeScrollIntoView from 'compute-scroll-into-view';
 import { Dispatch, KeyboardEvent, SyntheticEvent } from 'react';
 import keyNames from 'w3c-keyname';
+
 import { SpecialKey, Type } from './multishift-constants';
 import {
   ActionCreator,

--- a/packages/multishift/src/multishift.ts
+++ b/packages/multishift/src/multishift.ts
@@ -1,7 +1,8 @@
-import { debounce, includes, isNullOrUndefined, isUndefined, bool } from '@remirror/core-helpers';
+import { bool, debounce, includes, isNullOrUndefined, isUndefined } from '@remirror/core-helpers';
 import { useEffectOnce, useEffectOnUpdate, useTimeouts } from '@remirror/react-hooks';
 import composeRefs from '@seznam/compose-react-refs';
 import { ChangeEvent, HTMLProps, Ref, SyntheticEvent, useCallback, useEffect, useMemo, useRef } from 'react';
+
 import * as MultishiftActions from './multishift-action-creators';
 import {
   SPECIAL_INPUT_KEYS,

--- a/packages/prosemirror-suggest/src/__tests__/suggest-plugin.spec.ts
+++ b/packages/prosemirror-suggest/src/__tests__/suggest-plugin.spec.ts
@@ -1,4 +1,5 @@
 import { createEditor, doc, p } from 'jest-prosemirror';
+
 import { ExitReason } from '../suggest-constants';
 import { suggest } from '../suggest-plugin';
 import { SuggestExitHandlerParams, SuggestKeyBindingParams } from '../suggest-types';

--- a/packages/prosemirror-suggest/src/suggest-helpers.ts
+++ b/packages/prosemirror-suggest/src/suggest-helpers.ts
@@ -1,5 +1,6 @@
 import { isRegExp } from '@remirror/core-helpers';
 import escapeStringRegex from 'escape-string-regexp';
+
 import { Suggester } from './suggest-types';
 
 export const escapeChar = (char: string) => escapeStringRegex(char);

--- a/packages/prosemirror-suggest/src/suggest-plugin.ts
+++ b/packages/prosemirror-suggest/src/suggest-plugin.ts
@@ -1,6 +1,7 @@
 import { EditorSchema, EditorState } from '@remirror/core-types';
 import { getPluginState } from '@remirror/core-utils';
 import { Plugin, PluginKey } from 'prosemirror-state';
+
 import { SuggestState } from './suggest-state';
 import { Suggester } from './suggest-types';
 

--- a/packages/prosemirror-suggest/src/suggest-predicates.ts
+++ b/packages/prosemirror-suggest/src/suggest-predicates.ts
@@ -1,5 +1,6 @@
 import { bool, isString } from '@remirror/core-helpers';
 import { SelectionParams } from '@remirror/core-types';
+
 import { ChangeReason, ExitReason } from './suggest-constants';
 import {
   CompareMatchParams,

--- a/packages/prosemirror-suggest/src/suggest-state.ts
+++ b/packages/prosemirror-suggest/src/suggest-state.ts
@@ -1,3 +1,4 @@
+import { bool } from '@remirror/core-helpers';
 import {
   CompareStateParams,
   EditorSchema,
@@ -9,24 +10,24 @@ import {
   TextParams,
   TransactionParams,
 } from '@remirror/core-types';
-import { bool } from '@remirror/core-helpers';
 import { transactionChanged } from '@remirror/core-utils';
+import { Transaction } from 'prosemirror-state';
 import { Decoration, DecorationSet } from 'prosemirror-view';
+
 import { ChangeReason, DEFAULT_SUGGESTER, ExitReason } from './suggest-constants';
 import { isInvalidSplitReason, isJumpReason, isValidMatch } from './suggest-predicates';
 import {
+  AddIgnoredParams,
   CompareMatchParams,
+  RemoveIgnoredParams,
   SuggestCallbackParams,
   Suggester,
   SuggestKeyBindingParams,
   SuggestReasonMap,
   SuggestStateMatch,
   SuggestStateMatchReason,
-  AddIgnoredParams,
-  RemoveIgnoredParams,
 } from './suggest-types';
 import { findFromSuggesters, findReason, runKeyBindings } from './suggest-utils';
-import { Transaction } from 'prosemirror-state';
 
 /**
  * The suggestion state which manages the list of suggestions.

--- a/packages/prosemirror-suggest/src/suggest-types.ts
+++ b/packages/prosemirror-suggest/src/suggest-types.ts
@@ -1,4 +1,5 @@
 import { AnyFunction, EditorViewParams, FromToParams, TextParams } from '@remirror/core-types';
+
 import { ChangeReason, ExitReason } from './suggest-constants';
 
 /**

--- a/packages/prosemirror-suggest/src/suggest-utils.ts
+++ b/packages/prosemirror-suggest/src/suggest-utils.ts
@@ -9,7 +9,9 @@ import {
 } from '@remirror/core-types';
 import { selectionEmpty } from '@remirror/core-utils';
 import { keydownHandler } from 'prosemirror-keymap';
+
 import { ChangeReason, ExitReason } from './suggest-constants';
+import { createRegexFromSuggester, regexToString } from './suggest-helpers';
 import { isChange, isEntry, isExit, isJump, isMove } from './suggest-predicates';
 import {
   CompareMatchParams,
@@ -22,7 +24,6 @@ import {
   SuggestStateMatch,
   SuggestStateMatchParams,
 } from './suggest-types';
-import { regexToString, createRegexFromSuggester } from './suggest-helpers';
 
 /**
  * Small utility method for creating a match with the reason property available.

--- a/packages/test-keyboard/src/test-keyboard-utils.ts
+++ b/packages/test-keyboard/src/test-keyboard-utils.ts
@@ -1,5 +1,6 @@
 import { omit } from '@remirror/core-helpers';
 import { PlainObject } from '@remirror/core-types';
+
 import { KeyboardEventName, ModifierInformation } from './test-keyboard-types';
 import { SupportedCharacters, usKeyboardLayout } from './us-keyboard-layout';
 

--- a/packages/test-keyboard/src/test-keyboard.ts
+++ b/packages/test-keyboard/src/test-keyboard.ts
@@ -1,4 +1,5 @@
-import { take, includes } from '@remirror/core-helpers';
+import { includes, take } from '@remirror/core-helpers';
+
 import {
   KeyboardConstructorParams,
   KeyboardEventName,

--- a/support/dts-jest/jest-prosemirror.dts.ts
+++ b/support/dts-jest/jest-prosemirror.dts.ts
@@ -1,5 +1,5 @@
-import { EventType } from 'jest-prosemirror';
 import { EventType as DomEventType } from '@testing-library/dom';
+import { EventType } from 'jest-prosemirror';
 
 const eventType: EventType = 'abort';
 const domEventType: DomEventType = 'animationEnd';

--- a/support/jest/jest.framework.ts
+++ b/support/jest/jest.framework.ts
@@ -2,9 +2,10 @@
 /// <reference path="../../globals.d.ts" />
 
 import 'jest-extended';
+
 import toDiffableHtml from 'diffable-html';
-import { toMatchDiffSnapshot, getSnapshotDiffSerializer } from 'snapshot-diff';
 import { prosemirrorSerializer } from 'jest-prosemirror';
+import { getSnapshotDiffSerializer, toMatchDiffSnapshot } from 'snapshot-diff';
 
 expect.addSnapshotSerializer(getSnapshotDiffSerializer());
 expect.extend({ toMatchDiffSnapshot });

--- a/support/rollup/factory.js
+++ b/support/rollup/factory.js
@@ -1,11 +1,11 @@
+import chalk from 'chalk';
+import { join } from 'path';
+import autoExternal from 'rollup-plugin-auto-external';
 import babel from 'rollup-plugin-babel';
+import json from 'rollup-plugin-json';
 import builtins from 'rollup-plugin-node-builtins';
 import globals from 'rollup-plugin-node-globals';
-import json from 'rollup-plugin-json';
 import resolve from 'rollup-plugin-node-resolve';
-import autoExternal from 'rollup-plugin-auto-external';
-import { join } from 'path';
-import chalk from 'chalk';
 
 /* Inspired by https://github.com/ianstormtaylor/slate/blob/6302b2d9d2d6a62ba32e6a7d987db5db8f846eef/support/rollup/factory.js#L1-L148 */
 

--- a/support/rollup/rollup.config.js
+++ b/support/rollup/rollup.config.js
@@ -1,7 +1,8 @@
-import factory from './factory';
-import { join } from 'path';
-import { rollup, dependencies } from './config.json';
 import chalk from 'chalk';
+import { join } from 'path';
+
+import { dependencies, rollup } from './config.json';
+import factory from './factory';
 
 const { baseDir } = require('../scripts/helpers');
 

--- a/support/storybook/config.ts
+++ b/support/storybook/config.ts
@@ -1,4 +1,5 @@
 import { addDecorator, configure } from '@storybook/react';
+
 import { ThemeDecorator } from './decorators';
 
 const all = require.context('../../@remirror', true, /__stories__\/.*.stories.tsx$/);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9215,6 +9215,11 @@ eslint-plugin-react@^7.16.0, eslint-plugin-react@^7.17.0:
     prop-types "^15.7.2"
     resolve "^1.13.1"
 
+eslint-plugin-simple-import-sort@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-5.0.0.tgz#fd2abac52c0ae6050baf340c004b0b5d9aa76e8e"
+  integrity sha512-Zn6OppySnbwl/UonkzmMBbiFXZwe/tI9ZlSXwQek5h1FfPv3hcDTE3kG0SC70pBsKuVE8IMwZCMl0tKwcY89rw==
+
 eslint-plugin-unicorn@^14.0.1:
   version "14.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-unicorn/-/eslint-plugin-unicorn-14.0.1.tgz#6fa75872b6c0a4ed82a5f5b5854af3378fc78e41"


### PR DESCRIPTION
## Description


- `@remirror/core`: Remove deprecated `findNodeAtEndOfDoc` and `findNodeAtStartOfDoc` which can be replaced with `doc.firstChild` and `doc.lastChild`
- Add new [eslint-plugin-simple-import-sort](https://github.com/lydell/eslint-plugin-simple-import-sort) rule for easy sorting of imports
- Fix all eslint warnings and errors


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**][contributing] document.
- [x] My code follows the code style of this project and `yarn fix` runs successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `yarn test` .

[contributing]: https://github.com/ifiokjr/remirror/blob/master/docs/pages/contributing.md
