### PR TITLE
Demonstrate Social UI with additional plugins

### DIFF
--- a/@remirror/editor-social/package.json
+++ b/@remirror/editor-social/package.json
@@ -19,6 +19,7 @@
     "@emotion/styled": "^10.0.17",
     "@remirror/core": "^0.7.2",
     "@remirror/core-extensions": "^0.7.2",
+    "@remirror/extension-code-block": "^0.7.2",
     "@remirror/extension-emoji": "^0.7.2",
     "@remirror/extension-enhanced-link": "^0.7.2",
     "@remirror/extension-mention": "^0.7.2",
@@ -27,7 +28,8 @@
     "@remirror/ui": "^0.7.2",
     "@remirror/ui-buttons": "^0.7.2",
     "@remirror/ui-icons": "^0.7.2",
-    "multishift": "^0.7.2"
+    "multishift": "^0.7.2",
+    "refractor": "^2.10.0"
   },
   "peerDependencies": {
     "@emotion/core": "^10",

--- a/@remirror/editor-social/src/components/social-editor.tsx
+++ b/@remirror/editor-social/src/components/social-editor.tsx
@@ -391,6 +391,7 @@ export class SocialEditor extends PureComponent<SocialEditorProps, State> {
       formatter,
       supportedLanguages: supportedLanguagesProp = [],
       rich,
+      characterLimit,
       ...rest
     } = this.remirrorProps;
     const supportedLanguages = [...DEFAULT_LANGUAGES, ...supportedLanguagesProp];
@@ -457,6 +458,7 @@ export class SocialEditor extends PureComponent<SocialEditorProps, State> {
                 getMention={this.getMention}
                 users={this.users}
                 tags={this.tags}
+                characterLimit={characterLimit}
               />
               {children}
             </Fragment>

--- a/@remirror/editor-social/src/components/social-editor.tsx
+++ b/@remirror/editor-social/src/components/social-editor.tsx
@@ -2,7 +2,20 @@
 
 import { jsx } from '@emotion/core';
 import { deepMerge, isUndefined, omit, RemirrorTheme } from '@remirror/core';
-import { NodeCursorExtension, PlaceholderExtension } from '@remirror/core-extensions';
+import {
+  BlockquoteExtension,
+  BoldExtension,
+  CodeExtension,
+  HardBreakExtension,
+  ItalicExtension,
+  NodeCursorExtension,
+  ParagraphExtension,
+  PlaceholderExtension,
+  SSRHelperExtension,
+  StrikeExtension,
+  UnderlineExtension,
+} from '@remirror/core-extensions';
+import { CodeBlockExtension } from '@remirror/extension-code-block';
 import {
   EmojiExtension,
   EmojiExtensionOptions,
@@ -27,6 +40,10 @@ import {
   SuggestStateMatch,
 } from 'prosemirror-suggest';
 import { Fragment, PureComponent } from 'react';
+import bash from 'refractor/lang/bash';
+import markdown from 'refractor/lang/markdown';
+import tsx from 'refractor/lang/tsx';
+import typescript from 'refractor/lang/typescript';
 
 import { socialEditorTheme } from '../social-theme';
 import {
@@ -39,6 +56,8 @@ import {
 } from '../social-types';
 import { calculateNewIndexFromArrowPress, mapToActiveIndex } from '../social-utils';
 import { SocialEditorComponent } from './social-wrapper-component';
+
+const DEFAULT_LANGUAGES = [markdown, typescript, tsx, bash];
 
 interface State {
   activeMatcher: MatchName | undefined;
@@ -363,7 +382,18 @@ export class SocialEditor extends PureComponent<SocialEditorProps, State> {
       hideEmojiSuggestions,
     } = this.state;
 
-    const { children, placeholder, extensions = [], ...rest } = this.remirrorProps;
+    const {
+      children,
+      placeholder,
+      extensions = [],
+      syntaxTheme = 'atomDark',
+      defaultLanguage,
+      formatter,
+      supportedLanguages: supportedLanguagesProp = [],
+      rich,
+      ...rest
+    } = this.remirrorProps;
+    const supportedLanguages = [...DEFAULT_LANGUAGES, ...supportedLanguagesProp];
     return (
       <RemirrorThemeProvider theme={this.theme}>
         <RemirrorManager extensions={extensions}>
@@ -394,6 +424,26 @@ export class SocialEditor extends PureComponent<SocialEditorProps, State> {
             suggestionKeyBindings={this.emojiKeyBindings}
             onSuggestionExit={this.onEmojiSuggestionExit}
           />
+
+          {rich ? <RemirrorExtension Constructor={ParagraphExtension} /> : null}
+          {rich ? <RemirrorExtension Constructor={BoldExtension} /> : null}
+          {rich ? <RemirrorExtension Constructor={UnderlineExtension} /> : null}
+          {rich ? <RemirrorExtension Constructor={ItalicExtension} /> : null}
+          {rich ? <RemirrorExtension Constructor={BlockquoteExtension} /> : null}
+          {rich ? <RemirrorExtension Constructor={StrikeExtension} /> : null}
+          {rich ? <RemirrorExtension Constructor={CodeExtension} /> : null}
+          {rich ? <RemirrorExtension Constructor={HardBreakExtension} /> : null}
+          {rich ? (
+            <RemirrorExtension
+              Constructor={CodeBlockExtension}
+              supportedLanguages={supportedLanguages}
+              formatter={formatter}
+              syntaxTheme={syntaxTheme}
+              defaultLanguage={defaultLanguage}
+            />
+          ) : null}
+          {rich ? <RemirrorExtension Constructor={SSRHelperExtension} /> : null}
+
           <ManagedRemirrorProvider {...rest}>
             <Fragment>
               <SocialEditorComponent

--- a/@remirror/editor-social/src/components/social-wrapper-component.tsx
+++ b/@remirror/editor-social/src/components/social-wrapper-component.tsx
@@ -42,6 +42,11 @@ interface SocialEditorComponentProps extends MentionGetterParams, SetExitTrigger
    * Whether or not suggestions have been hidden by pressing the escape key
    */
   hideSuggestions: boolean;
+
+  /**
+   * Show a typing hint that limits the number of characters; defaults to 140, set to null to disable.
+   */
+  characterLimit?: number;
 }
 
 /**
@@ -60,6 +65,7 @@ export const SocialEditorComponent: FC<SocialEditorComponentProps> = ({
   emojiList,
   hideEmojiSuggestions,
   emojiCommand,
+  characterLimit = 140,
 }) => {
   const {
     getRootProps,
@@ -70,9 +76,11 @@ export const SocialEditorComponent: FC<SocialEditorComponentProps> = ({
     <div>
       <EditorWrapper data-testid='social-editor-wrapper'>
         <div {...getRootProps()} data-testid='remirror-editor' />
-        <CharacterCountWrapper>
-          <CharacterCountIndicator characters={{ total: 140, used: content.length }} />
-        </CharacterCountWrapper>
+        {characterLimit ? (
+          <CharacterCountWrapper>
+            <CharacterCountIndicator characters={{ total: characterLimit, used: content.length }} />
+          </CharacterCountWrapper>
+        ) : null}
         {hideEmojiSuggestions || !emojiCommand ? null : (
           <EmojiSuggestions highlightedIndex={activeEmojiIndex} data={emojiList} command={emojiCommand} />
         )}

--- a/@remirror/editor-social/src/social-types.ts
+++ b/@remirror/editor-social/src/social-types.ts
@@ -1,5 +1,6 @@
 import { RemirrorTheme } from '@remirror/core';
 import { BaseExtensions, NodeCursorExtension, PlaceholderExtension } from '@remirror/core-extensions';
+import { CodeBlockExtensionOptions } from '@remirror/extension-code-block';
 import { EmojiExtension } from '@remirror/extension-emoji';
 import { EnhancedLinkExtension } from '@remirror/extension-enhanced-link';
 import { MentionExtension } from '@remirror/extension-mention';
@@ -15,7 +16,8 @@ export type OnMentionChangeParams = MentionState & {
 
 export interface SocialEditorProps
   extends Partial<ManagedRemirrorProviderProps<SocialExtensions>>,
-    Pick<RemirrorManagerProps, 'extensions'> {
+    Pick<RemirrorManagerProps, 'extensions'>,
+    Pick<CodeBlockExtensionOptions, 'supportedLanguages' | 'defaultLanguage' | 'syntaxTheme' | 'formatter'> {
   /**
    * Set this to true to hide the character indicator.
    */
@@ -50,6 +52,11 @@ export interface SocialEditorProps
    * The theme to be used for setting .
    */
   theme?: Partial<RemirrorTheme & Partial<RemirrorTheme['colors']>>;
+
+  /**
+   * If true, enables richer text formatting (bold, italic, underline, code blocks, etc)
+   */
+  rich?: boolean;
 }
 
 interface BaseMentionState {

--- a/@remirror/editor-social/src/social-types.ts
+++ b/@remirror/editor-social/src/social-types.ts
@@ -19,9 +19,9 @@ export interface SocialEditorProps
     Pick<RemirrorManagerProps, 'extensions'>,
     Pick<CodeBlockExtensionOptions, 'supportedLanguages' | 'defaultLanguage' | 'syntaxTheme' | 'formatter'> {
   /**
-   * Set this to true to hide the character indicator.
+   * Show a typing hint that limits the number of characters; defaults to 140, set to null to disable.
    */
-  hideCharacterIndicator?: boolean;
+  characterLimit?: number;
 
   /**
    * The message to show when the editor is empty.

--- a/@remirror/showcase/src/rich-social.tsx
+++ b/@remirror/showcase/src/rich-social.tsx
@@ -63,6 +63,7 @@ export const ExampleRichSocialEditor = (props: Partial<SocialEditorProps>) => {
   return (
     <SocialEditor
       {...props}
+      rich
       attributes={{ 'data-testid': 'editor-social' }}
       userData={userMatches}
       tagData={tagMatches}

--- a/@remirror/showcase/src/rich-social.tsx
+++ b/@remirror/showcase/src/rich-social.tsx
@@ -68,6 +68,7 @@ export const ExampleRichSocialEditor = (props: Partial<SocialEditorProps>) => {
       userData={userMatches}
       tagData={tagMatches}
       onMentionChange={onChange}
+      characterLimit={500}
     />
   );
 };

--- a/@remirror/showcase/src/rich-social.tsx
+++ b/@remirror/showcase/src/rich-social.tsx
@@ -97,7 +97,20 @@ export const RICH_SOCIAL_SHOWCASE_CONTENT = {
         },
         {
           type: 'text',
-          text: ' has proven to me most helpful!',
+          text: ' has proven to me ',
+        },
+        {
+          type: 'text',
+          text: 'most',
+          marks: [
+            {
+              type: 'italic',
+            },
+          ],
+        },
+        {
+          type: 'text',
+          text: ' helpful!',
         },
       ],
     },
@@ -123,12 +136,25 @@ export const RICH_SOCIAL_SHOWCASE_CONTENT = {
       ],
     },
     {
+      type: 'codeBlock',
+      attrs: { language: 'markdown' },
+      content: [
+        {
+          type: 'text',
+          text:
+            '## Simple Code Blocks\n\n```js\nlog("with code fence support");\n```\n\n```bash\necho "fun times"\n```\n\nUse Shift-Enter or Mod-Enter to hard break out of the code block',
+        },
+      ],
+    },
+    {
       type: 'paragraph',
       content: [
         {
           type: 'text',
-          text: 'Emojis still make me smile 😋 🙈',
+          text: 'Emojis ',
         },
+        { type: 'text', text: 'still', marks: [{ type: 'strike' }] },
+        { type: 'text', text: ' make me smile 😋 🙈' },
         {
           type: 'text',
           text: " and I'm here for that.",

--- a/@remirror/showcase/src/rich-social.tsx
+++ b/@remirror/showcase/src/rich-social.tsx
@@ -1,0 +1,137 @@
+/** @jsx jsx */
+
+import { jsx } from '@emotion/core';
+import { startCase, take } from '@remirror/core';
+import {
+  ActiveTagData,
+  ActiveUserData,
+  OnMentionChangeParams,
+  SocialEditor,
+  SocialEditorProps,
+  UserData,
+} from '@remirror/editor-social';
+import matchSorter from 'match-sorter';
+import { useState } from 'react';
+
+import { fakeUsers } from './data/fake-users';
+
+const fakeTags = [
+  'Tags',
+  'Fake',
+  'Help',
+  'TypingByHand',
+  'DontDoThisAgain',
+  'ZoroIsAwesome',
+  'ThisIsATagList',
+  'NeedsStylingSoon',
+  'LondonHits',
+  'MCM',
+];
+
+const userData: UserData[] = fakeUsers.results.map(
+  (user): UserData => ({
+    avatarUrl: user.picture.thumbnail,
+    displayName: startCase(`${user.name.first} ${user.name.last}`),
+    uid: user.login.uuid,
+    username: user.login.username,
+  }),
+);
+
+export const ExampleRichSocialEditor = (props: Partial<SocialEditorProps>) => {
+  const [mention, setMention] = useState<OnMentionChangeParams>();
+
+  const onChange = (params: OnMentionChangeParams) => {
+    setMention(params);
+  };
+
+  const userMatches: ActiveUserData[] =
+    mention && mention.name === 'at' && mention.query.length
+      ? take(
+          matchSorter(userData, mention.query, { keys: ['username', 'displayName'] }),
+          6,
+        ).map((user, index) => ({ ...user, active: index === mention.activeIndex }))
+      : [];
+
+  const tagMatches: ActiveTagData[] =
+    mention && mention.name === 'tag' && mention.query.length
+      ? take(matchSorter(fakeTags, mention.query), 6).map((tag, index) => ({
+          tag,
+          active: index === mention.activeIndex,
+        }))
+      : [];
+
+  return (
+    <SocialEditor
+      {...props}
+      attributes={{ 'data-testid': 'editor-social' }}
+      userData={userMatches}
+      tagData={tagMatches}
+      onMentionChange={onChange}
+    />
+  );
+};
+
+export const RICH_SOCIAL_SHOWCASE_CONTENT = {
+  type: 'doc',
+  content: [
+    {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'text',
+          marks: [
+            {
+              type: 'mention',
+              attrs: {
+                id: 'blueladybug185',
+                label: '@blueladybug185',
+                name: 'at',
+                href: '/blueladybug185',
+                role: 'presentation',
+              },
+            },
+          ],
+          text: '@blueladybug185',
+        },
+        {
+          type: 'text',
+          text: ' has proven to me most helpful!',
+        },
+      ],
+    },
+    {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'text',
+          marks: [
+            {
+              type: 'enhancedLink',
+              attrs: {
+                href: 'http://Random.com',
+              },
+            },
+          ],
+          text: 'Random.com',
+        },
+        {
+          type: 'text',
+          text: ' on the other hand has not.',
+        },
+      ],
+    },
+    {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'text',
+          text: 'Emojis still make me smile 😋 🙈',
+        },
+        {
+          type: 'text',
+          text: " and I'm here for that.",
+        },
+      ],
+    },
+  ],
+};

--- a/@remirror/showcase/tsconfig.prod.json
+++ b/@remirror/showcase/tsconfig.prod.json
@@ -5,7 +5,8 @@
     "baseUrl": "src",
     "paths": {},
     "composite": true,
-    "emitDeclarationOnly": true,
+    "emitDeclarationOnly": false,
+    "module": "commonjs",
     "declaration": true,
     "declarationMap": true,
     "rootDir": "src"

--- a/docs/pages/contributing.md
+++ b/docs/pages/contributing.md
@@ -176,3 +176,7 @@ available at [http://contributor-covenant.org/version/1/4][version]
 [gatsby]: https://www.gatsbyjs.org/
 [repo]: https://github.com/ifiokjr/remirror
 [husky]: https://github.com/typicode/husky
+
+### Troubleshooting
+
+If you're getting errors like `ReferenceError: CodeBlockExtension is not defined` but you know you've imported it, it might be because you've not added it as a dependency to the relevant `package.json`. Rather than throwing an error in this case, rollup (?) seems to just drop the import statement but still persist the lines where the import is used.

--- a/docs/pages/guides/quickstart.mdx
+++ b/docs/pages/guides/quickstart.mdx
@@ -4,7 +4,10 @@ title: Quickstart Guide
 
 # Quickstart Guide
 
-Remirror is comprised of core librarys like `@remirror/core` and UI libraries
+_A really quick way to get started is to [spin up our Next.js
+example](https://github.com/ifiokjr/remirror/blob/canary/examples/with-next/readme.md#getting-started)._
+
+Remirror is comprised of core libraries like `@remirror/core` and UI libraries
 like `@remirror/editor-social`.
 
 The easiest way to get started is by using a UI library and for the purposes of

--- a/docs/pages/introduction.mdx
+++ b/docs/pages/introduction.mdx
@@ -6,8 +6,10 @@ title: Introduction
 
 Thanks for taking the time to explore this project.
 
-At the moment the focus is on releasing a stable api and while this is ongoing
+At the moment the focus is on releasing a stable API and while this is ongoing
 documentation has slipped from being the priority.
 
-Right now the best way to understand the library is to read through the codebase
-and take a look at how existing editors have been structured.
+Right now the best way to understand the library is to read through the
+codebase and take a look at how existing editors have been structured. A
+quick way to get started is to [spin up our Next.js
+example](https://github.com/ifiokjr/remirror/blob/canary/examples/with-next/readme.md#getting-started).

--- a/examples/with-next/components/layout.tsx
+++ b/examples/with-next/components/layout.tsx
@@ -24,8 +24,16 @@ const Layout: FunctionComponent<Props> = ({ children, title = 'This is the defau
             <a>Social UI</a>
           </Link>{' '}
           |{' '}
+          <Link href='/editor/social/content'>
+            <a>Social UI with content</a>
+          </Link>{' '}
+          |{' '}
           <Link href='/editor/wysiwyg'>
             <a>Wysiwyg UI</a>
+          </Link>{' '}
+          |{' '}
+          <Link href='/editor/wysiwyg/content'>
+            <a>Wysiwyg UI with content</a>
           </Link>{' '}
           |{' '}
           <Link href='/initial-props'>

--- a/examples/with-next/components/layout.tsx
+++ b/examples/with-next/components/layout.tsx
@@ -1,5 +1,4 @@
 import Head from 'next/head';
-import Link from 'next/link';
 import React, { FunctionComponent } from 'react';
 
 interface Props {
@@ -14,38 +13,7 @@ const Layout: FunctionComponent<Props> = ({ children, title = 'This is the defau
         <meta charSet='utf-8' />
         <meta name='viewport' content='initial-scale=1.0, width=device-width' />
       </Head>
-      <header>
-        <nav>
-          <Link href='/'>
-            <a>Home</a>
-          </Link>{' '}
-          |{' '}
-          <Link href='/editor/social'>
-            <a>Social UI</a>
-          </Link>{' '}
-          |{' '}
-          <Link href='/editor/social/content'>
-            <a>Social UI with content</a>
-          </Link>{' '}
-          |{' '}
-          <Link href='/editor/wysiwyg'>
-            <a>Wysiwyg UI</a>
-          </Link>{' '}
-          |{' '}
-          <Link href='/editor/wysiwyg/content'>
-            <a>Wysiwyg UI with content</a>
-          </Link>{' '}
-          |{' '}
-          <Link href='/initial-props'>
-            <a>With Initial Props</a>
-          </Link>
-        </nav>
-      </header>
       {children}
-      <footer>
-        <hr />
-        <span>I&apos;m here to stay (Footer)</span>
-      </footer>
     </div>
   );
 };

--- a/examples/with-next/pages/editor/rich-social/content.tsx
+++ b/examples/with-next/pages/editor/rich-social/content.tsx
@@ -6,4 +6,4 @@ const RichSocialEditorWithContent: FC = () => (
 );
 RichSocialEditorWithContent.displayName = 'SocialEditorWithContent';
 
-export default SocialEditorWithContent;
+export default RichSocialEditorWithContent;

--- a/examples/with-next/pages/editor/rich-social/content.tsx
+++ b/examples/with-next/pages/editor/rich-social/content.tsx
@@ -1,0 +1,9 @@
+import { ExampleRichSocialEditor, RICH_SOCIAL_SHOWCASE_CONTENT } from '@remirror/showcase/lib/rich-social';
+import React, { FC } from 'react';
+
+const RichSocialEditorWithContent: FC = () => (
+  <ExampleRichSocialEditor initialContent={RICH_SOCIAL_SHOWCASE_CONTENT} suppressHydrationWarning={true} />
+);
+RichSocialEditorWithContent.displayName = 'SocialEditorWithContent';
+
+export default SocialEditorWithContent;

--- a/examples/with-next/pages/editor/rich-social/index.tsx
+++ b/examples/with-next/pages/editor/rich-social/index.tsx
@@ -1,0 +1,7 @@
+import { ExampleRichSocialEditor } from '@remirror/showcase/lib/rich-social';
+import React, { FC } from 'react';
+
+const RichSocialEditor: FC = () => <ExampleRichSocialEditor suppressHydrationWarning={true} />;
+RichSocialEditor.displayName = 'SocialEditor';
+
+export default RichSocialEditor;

--- a/examples/with-next/pages/index.tsx
+++ b/examples/with-next/pages/index.tsx
@@ -7,12 +7,19 @@ import Layout from '../components/layout';
 const IndexPage: NextPage = () => {
   return (
     <Layout title='Home | Next.js + TypeScript Example'>
-      <h1>Hello Next.js 👋</h1>
-      <p>
-        <Link href='/about'>
-          <a>About</a>
-        </Link>
-      </p>
+      <h1>Next.js Remirror examples 👋</h1>
+      <p>Choose the example you wish to see:</p>
+      <ul>
+        <li>
+          SocialUI: <Link href='/editor/social'>blank</Link> /{' '}
+          <Link href='/editor/social/content'>with content</Link>
+        </li>
+
+        <li>
+          <abbr title='What you see is what you get'>WYSIWYG</abbr>: <Link href='/editor/wysiwyg'>blank</Link>{' '}
+          / <Link href='/editor/wysiwyg/content'>with content</Link>
+        </li>
+      </ul>
     </Layout>
   );
 };

--- a/examples/with-next/pages/index.tsx
+++ b/examples/with-next/pages/index.tsx
@@ -12,7 +12,9 @@ const IndexPage: NextPage = () => {
       <ul>
         <li>
           SocialUI: <Link href='/editor/social'>blank</Link> /{' '}
-          <Link href='/editor/social/content'>with content</Link>
+          <Link href='/editor/social/content'>with content</Link> /{' '}
+          <Link href='/editor/rich-social'>rich text</Link> /{' '}
+          <Link href='/editor/rich-social/content'>rich text with content</Link>
         </li>
 
         <li>

--- a/examples/with-next/readme.md
+++ b/examples/with-next/readme.md
@@ -1,3 +1,23 @@
 # Remirror Next.js example
 
 This is a small project demonstrating the usage of remirror with Next.JS.
+
+## Getting started
+
+Clone the remirror repository, install the dependencies, and then change to this folder and run `yarn dev`:
+
+```bash
+git clone git@github.com:ifiokjr/remirror.git
+cd remirror
+yarn
+cd examples/with-next
+yarn dev
+```
+
+After a few seconds you should receive a `[ ready ]` message, and a URL to open such as http://localhost:3000. You can use the links at the top to visit different examples:
+
+![Home page](screenshots/home.png)
+
+![Social](screenshots/social.png)
+
+![WYSIWYG](screenshots/wysiwyg.png)

--- a/examples/with-next/screenshots/home.png
+++ b/examples/with-next/screenshots/home.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3f769dc46b1c0f391e9d2fd109d4aa3e2968fb2deea266f53984683125f4ef4
+size 22004

--- a/examples/with-next/screenshots/social.png
+++ b/examples/with-next/screenshots/social.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b43217a9e9c54024b23b08db6b79509b3157bf38d06d52a119166aa905471840
+size 24752

--- a/examples/with-next/screenshots/wysiwyg.png
+++ b/examples/with-next/screenshots/wysiwyg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a16e57b3b0c1170ddec74b13b016bc31d424248c1ca5fd9bdbd8ada0d4daed7
+size 23308

--- a/readme.md
+++ b/readme.md
@@ -38,8 +38,23 @@
 
 <br />
 
+### Status
+
+Remirror is still undergoing heavy development, but is used in production by
+at least one company. At the moment the focus is on releasing a stable API
+and while this is ongoing documentation has slipped from being the priority.
+
+Right now the best way to understand the library is to read through the
+codebase and take a look at how existing editors have been structured. A
+quick way to get started is to [spin up our Next.js
+example](https://github.com/ifiokjr/remirror/blob/canary/examples/with-next/readme.md#getting-started).
+
+### Documentation
+
+View our documentation website at https://docs.remirror.org/
+
 - [Introduction]
-- [Installation]
+  <!-- - [Installation] -->
 - [Getting started]
 
 <br />


### PR DESCRIPTION
## Description

WARNING: this is based off of #184, so ignore the first couple commits as they should be reviewed separately.

This should provide an example of how to use additional plugins with the social editor, to make it clear that changes to core are not required to accomplish this. This has not yet been achieved - this is a request for input.

## Checklist

WORK IN PROGRESS!

- [x] I have read the [**contributing**][contributing] document.
- [ ] My code follows the code style of this project and `yarn fix` runs successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `yarn test` .

## Screenshots

![Screenshot_20200109_122638](https://user-images.githubusercontent.com/129910/72067695-4ed48a80-32db-11ea-98fb-e9692166bda0.png)


[contributing]: https://github.com/ifiokjr/remirror/blob/master/docs/pages/contributing.md
