### PR TITLE
feat(social): allow overriding character limit in Social UI

### DIFF
--- a/@remirror/editor-social/src/components/social-editor.tsx
+++ b/@remirror/editor-social/src/components/social-editor.tsx
@@ -363,7 +363,7 @@ export class SocialEditor extends PureComponent<SocialEditorProps, State> {
       hideEmojiSuggestions,
     } = this.state;
 
-    const { children, placeholder, extensions = [], ...rest } = this.remirrorProps;
+    const { children, placeholder, extensions = [], characterLimit, ...rest } = this.remirrorProps;
     return (
       <RemirrorThemeProvider theme={this.theme}>
         <RemirrorManager extensions={extensions}>
@@ -407,6 +407,7 @@ export class SocialEditor extends PureComponent<SocialEditorProps, State> {
                 getMention={this.getMention}
                 users={this.users}
                 tags={this.tags}
+                characterLimit={characterLimit}
               />
               {children}
             </Fragment>

--- a/@remirror/editor-social/src/components/social-wrapper-component.tsx
+++ b/@remirror/editor-social/src/components/social-wrapper-component.tsx
@@ -42,6 +42,11 @@ interface SocialEditorComponentProps extends MentionGetterParams, SetExitTrigger
    * Whether or not suggestions have been hidden by pressing the escape key
    */
   hideSuggestions: boolean;
+
+  /**
+   * Display a typing hint that limits the number of characters to this number. Defaults to 140, set to `null` to disable.
+   */
+  characterLimit?: number | null;
 }
 
 /**
@@ -60,6 +65,7 @@ export const SocialEditorComponent: FC<SocialEditorComponentProps> = ({
   emojiList,
   hideEmojiSuggestions,
   emojiCommand,
+  characterLimit = 140,
 }) => {
   const {
     getRootProps,
@@ -70,9 +76,11 @@ export const SocialEditorComponent: FC<SocialEditorComponentProps> = ({
     <div>
       <EditorWrapper data-testid='social-editor-wrapper'>
         <div {...getRootProps()} data-testid='remirror-editor' />
-        <CharacterCountWrapper>
-          <CharacterCountIndicator characters={{ total: 140, used: content.length }} />
-        </CharacterCountWrapper>
+        {characterLimit != null ? (
+          <CharacterCountWrapper>
+            <CharacterCountIndicator characters={{ total: characterLimit, used: content.length }} />
+          </CharacterCountWrapper>
+        ) : null}
         {hideEmojiSuggestions || !emojiCommand ? null : (
           <EmojiSuggestions highlightedIndex={activeEmojiIndex} data={emojiList} command={emojiCommand} />
         )}

--- a/@remirror/editor-social/src/social-types.ts
+++ b/@remirror/editor-social/src/social-types.ts
@@ -17,9 +17,9 @@ export interface SocialEditorProps
   extends Partial<ManagedRemirrorProviderProps<SocialExtensions>>,
     Pick<RemirrorManagerProps, 'extensions'> {
   /**
-   * Set this to true to hide the character indicator.
+   * Display a typing hint that limits the number of characters to this number. Defaults to 140, set to `null` to disable.
    */
-  hideCharacterIndicator?: boolean;
+  characterLimit?: number | null;
 
   /**
    * The message to show when the editor is empty.

--- a/examples/with-next/pages/editor/social/content.tsx
+++ b/examples/with-next/pages/editor/social/content.tsx
@@ -2,7 +2,11 @@ import { ExampleSocialEditor, SOCIAL_SHOWCASE_CONTENT } from '@remirror/showcase
 import React, { FC } from 'react';
 
 const SocialEditorWithContent: FC = () => (
-  <ExampleSocialEditor initialContent={SOCIAL_SHOWCASE_CONTENT} suppressHydrationWarning={true} />
+  <ExampleSocialEditor
+    initialContent={SOCIAL_SHOWCASE_CONTENT}
+    suppressHydrationWarning={true}
+    characterLimit={280}
+  />
 );
 SocialEditorWithContent.displayName = 'SocialEditorWithContent';
 


### PR DESCRIPTION
## Description

There was previously no way to override the social character limit, and the `hideCharacterIndicator` prop did nothing. This PR fixes both issues.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**][contributing] document.
- [x] My code follows the code style of this project and `yarn fix` runs successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `yarn test` .

[contributing]: https://github.com/ifiokjr/remirror/blob/master/docs/pages/contributing.md
