### PR TITLE
Fix with-next instructions

### DIFF
--- a/examples/with-next/readme.md
+++ b/examples/with-next/readme.md
@@ -10,6 +10,7 @@ Clone the remirror repository, install the dependencies, and then change to this
 git clone git@github.com:ifiokjr/remirror.git
 cd remirror
 yarn
+yarn build
 cd examples/with-next
 yarn dev
 ```


### PR DESCRIPTION
## Description

Without this, the showcase modules could not be found.

Following the example's instruction, I got the following errors.

```console
$ git clone git@github.com:ifiokjr/remirror.git
$ cd remirror
$ yarn
$ cd examples/with-next
$ yarn dev
```

Browsing localhost:3000 works, but when clicking on the WYSIWYG example I get the following error.

```
Failed to compile

./pages/editor/wysiwyg/index.tsx
Module not found: Can't resolve '@remirror/showcase/lib/wysiwyg' in '~/dev/remirror/examples/with-next/pages/editor/wysiwyg'
```

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/ifiokjr/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `yarn fix` runs successfully.
- [x] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `yarn test` .

## Screenshots

### Before

![Screenshot 2020-01-13 at 13 13 09](https://user-images.githubusercontent.com/1301152/72256151-c9b5e200-3608-11ea-8e95-28486cfc1401.png)
![Screenshot 2020-01-13 at 13 13 43](https://user-images.githubusercontent.com/1301152/72256156-cc183c00-3608-11ea-95dd-9aca2c981d1b.png)

### After

![Screenshot 2020-01-13 at 13 30 49](https://user-images.githubusercontent.com/1301152/72256271-0d105080-3609-11ea-976b-ddb9b007f6b8.png)

