### PR TITLE
Fix TypeScript error with useId() from @reach/auto-id

### DIFF
--- a/packages/multishift/src/multishift-utils.ts
+++ b/packages/multishift/src/multishift-utils.ts
@@ -262,7 +262,7 @@ export const callChangeHandlers = <GItem = any>(
  * Get the ids for each element.
  */
 export const getElementIds = (
-  defaultId: string,
+  defaultId: string | number,
   { id, labelId, menuId, getItemA11yId, toggleButtonId, inputId }: MultishiftA11yIdProps = Object.create(
     null,
   ),


### PR DESCRIPTION
## Description

`useId()` from `@react/auto-id` returns a number. Rather than casting this to a String in `useElementIds` I figured it made more sense to make the `getElementIds` call more liberal.

## Checklist

- [x] I have read the [**contributing**](https://github.com/ifiokjr/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `yarn fix` runs successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `yarn test` .

