### PR TITLE
fix(core-extensions): make `keys()` return `KeyboardBindings`

### DIFF
--- a/.changeset/spotty-bananas-remain.md
+++ b/.changeset/spotty-bananas-remain.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core-extensions': patch
+---
+
+Make all built-in extensions' `keys()` return a `KeyboardBindings` object instead of a specific object (#206)

--- a/@remirror/core-extensions/src/extensions/history-extension.ts
+++ b/@remirror/core-extensions/src/extensions/history-extension.ts
@@ -1,4 +1,4 @@
-import { Extension, isFunction } from '@remirror/core';
+import { Extension, isFunction, KeyboardBindings } from '@remirror/core';
 import {
   BaseExtensionOptions,
   CommandFunction,
@@ -89,7 +89,7 @@ export class HistoryExtension extends Extension<HistoryExtensionOptions> {
   /**
    * Adds the default key mappings for undo and redo.
    */
-  public keys() {
+  public keys():KeyboardBindings {
     return {
       'Mod-y': () => false,
       'Mod-z': this.wrapMethod(undo),

--- a/@remirror/core-extensions/src/extensions/history-extension.ts
+++ b/@remirror/core-extensions/src/extensions/history-extension.ts
@@ -89,7 +89,7 @@ export class HistoryExtension extends Extension<HistoryExtensionOptions> {
   /**
    * Adds the default key mappings for undo and redo.
    */
-  public keys():KeyboardBindings {
+  public keys(): KeyboardBindings {
     return {
       'Mod-y': () => false,
       'Mod-z': this.wrapMethod(undo),

--- a/@remirror/core-extensions/src/marks/bold-extension.ts
+++ b/@remirror/core-extensions/src/marks/bold-extension.ts
@@ -3,6 +3,7 @@ import {
   ExtensionManagerMarkTypeParams,
   isElementDOMNode,
   isString,
+  KeyboardBindings,
   MarkExtension,
   MarkExtensionSpec,
   MarkGroup,
@@ -38,7 +39,7 @@ export class BoldExtension extends MarkExtension {
     };
   }
 
-  public keys({ type }: ExtensionManagerMarkTypeParams) {
+  public keys({ type }: ExtensionManagerMarkTypeParams):KeyboardBindings {
     return {
       'Mod-b': toggleMark(type),
     };

--- a/@remirror/core-extensions/src/marks/bold-extension.ts
+++ b/@remirror/core-extensions/src/marks/bold-extension.ts
@@ -39,7 +39,7 @@ export class BoldExtension extends MarkExtension {
     };
   }
 
-  public keys({ type }: ExtensionManagerMarkTypeParams):KeyboardBindings {
+  public keys({ type }: ExtensionManagerMarkTypeParams): KeyboardBindings {
     return {
       'Mod-b': toggleMark(type),
     };

--- a/@remirror/core-extensions/src/marks/code-extension.ts
+++ b/@remirror/core-extensions/src/marks/code-extension.ts
@@ -1,6 +1,7 @@
 import {
   CommandMarkTypeParams,
   ExtensionManagerMarkTypeParams,
+  KeyboardBindings,
   MarkExtension,
   MarkExtensionSpec,
   MarkGroup,
@@ -22,7 +23,7 @@ export class CodeExtension extends MarkExtension {
     };
   }
 
-  public keys({ type }: ExtensionManagerMarkTypeParams) {
+  public keys({ type }: ExtensionManagerMarkTypeParams): KeyboardBindings {
     return {
       'Mod-`': toggleMark(type),
     };

--- a/@remirror/core-extensions/src/marks/italic-extension.ts
+++ b/@remirror/core-extensions/src/marks/italic-extension.ts
@@ -1,6 +1,7 @@
 import {
   CommandMarkTypeParams,
   ExtensionManagerMarkTypeParams,
+  KeyboardBindings,
   MarkExtension,
   MarkExtensionSpec,
   MarkGroup,
@@ -22,7 +23,7 @@ export class ItalicExtension extends MarkExtension {
     };
   }
 
-  public keys({ type }: ExtensionManagerMarkTypeParams) {
+  public keys({ type }: ExtensionManagerMarkTypeParams) : KeyboardBindings{
     return {
       'Mod-i': toggleMark(type),
     };

--- a/@remirror/core-extensions/src/marks/italic-extension.ts
+++ b/@remirror/core-extensions/src/marks/italic-extension.ts
@@ -23,7 +23,7 @@ export class ItalicExtension extends MarkExtension {
     };
   }
 
-  public keys({ type }: ExtensionManagerMarkTypeParams) : KeyboardBindings{
+  public keys({ type }: ExtensionManagerMarkTypeParams): KeyboardBindings {
     return {
       'Mod-i': toggleMark(type),
     };

--- a/@remirror/core-extensions/src/marks/strike-extension.ts
+++ b/@remirror/core-extensions/src/marks/strike-extension.ts
@@ -37,7 +37,7 @@ export class StrikeExtension extends MarkExtension {
     };
   }
 
-  public keys({ type }: ExtensionManagerMarkTypeParams):KeyboardBindings {
+  public keys({ type }: ExtensionManagerMarkTypeParams): KeyboardBindings {
     return {
       'Mod-d': toggleMark(type),
     };

--- a/@remirror/core-extensions/src/marks/strike-extension.ts
+++ b/@remirror/core-extensions/src/marks/strike-extension.ts
@@ -1,6 +1,7 @@
 import {
   CommandMarkTypeParams,
   ExtensionManagerMarkTypeParams,
+  KeyboardBindings,
   MarkExtension,
   MarkExtensionSpec,
   MarkGroup,
@@ -36,7 +37,7 @@ export class StrikeExtension extends MarkExtension {
     };
   }
 
-  public keys({ type }: ExtensionManagerMarkTypeParams) {
+  public keys({ type }: ExtensionManagerMarkTypeParams):KeyboardBindings {
     return {
       'Mod-d': toggleMark(type),
     };

--- a/@remirror/core-extensions/src/marks/underline-extension.ts
+++ b/@remirror/core-extensions/src/marks/underline-extension.ts
@@ -1,6 +1,7 @@
 import {
   CommandMarkTypeParams,
   ExtensionManagerMarkTypeParams,
+  KeyboardBindings,
   MarkExtension,
   MarkExtensionSpec,
   MarkGroup,
@@ -28,7 +29,7 @@ export class UnderlineExtension extends MarkExtension {
     };
   }
 
-  public keys({ type }: ExtensionManagerMarkTypeParams) {
+  public keys({ type }: ExtensionManagerMarkTypeParams)  : KeyboardBindings {
     return {
       'Mod-u': toggleMark(type),
     };

--- a/@remirror/core-extensions/src/marks/underline-extension.ts
+++ b/@remirror/core-extensions/src/marks/underline-extension.ts
@@ -29,7 +29,7 @@ export class UnderlineExtension extends MarkExtension {
     };
   }
 
-  public keys({ type }: ExtensionManagerMarkTypeParams)  : KeyboardBindings {
+  public keys({ type }: ExtensionManagerMarkTypeParams): KeyboardBindings {
     return {
       'Mod-u': toggleMark(type),
     };

--- a/@remirror/core-extensions/src/nodes/blockquote-extension.ts
+++ b/@remirror/core-extensions/src/nodes/blockquote-extension.ts
@@ -57,7 +57,7 @@ export class BlockquoteExtension extends NodeExtension {
     `;
   }
 
-  public keys({ type }: ExtensionManagerNodeTypeParams):KeyboardBindings {
+  public keys({ type }: ExtensionManagerNodeTypeParams): KeyboardBindings {
     return {
       'Ctrl->': toggleWrap(type),
     };

--- a/@remirror/core-extensions/src/nodes/blockquote-extension.ts
+++ b/@remirror/core-extensions/src/nodes/blockquote-extension.ts
@@ -2,6 +2,7 @@ import {
   CommandNodeTypeParams,
   EDITOR_CLASS_SELECTOR,
   ExtensionManagerNodeTypeParams,
+  KeyboardBindings,
   NodeExtension,
   NodeExtensionSpec,
   NodeGroup,
@@ -56,7 +57,7 @@ export class BlockquoteExtension extends NodeExtension {
     `;
   }
 
-  public keys({ type }: ExtensionManagerNodeTypeParams) {
+  public keys({ type }: ExtensionManagerNodeTypeParams):KeyboardBindings {
     return {
       'Ctrl->': toggleWrap(type),
     };

--- a/@remirror/core-extensions/src/nodes/bullet-list-extension.ts
+++ b/@remirror/core-extensions/src/nodes/bullet-list-extension.ts
@@ -1,6 +1,7 @@
 import {
   CommandNodeTypeParams,
   ExtensionManagerNodeTypeParams,
+  KeyboardBindings,
   NodeExtension,
   NodeExtensionSpec,
   NodeGroup,
@@ -27,7 +28,7 @@ export class BulletListExtension extends NodeExtension {
     return { toggleBulletList: () => toggleList(type, schema.nodes.listItem) };
   }
 
-  public keys({ type, schema }: ExtensionManagerNodeTypeParams) {
+  public keys({ type, schema }: ExtensionManagerNodeTypeParams): KeyboardBindings {
     return {
       'Shift-Ctrl-8': toggleList(type, schema.nodes.listItem),
     };

--- a/@remirror/core-extensions/src/nodes/hard-break-extension.ts
+++ b/@remirror/core-extensions/src/nodes/hard-break-extension.ts
@@ -1,4 +1,4 @@
-import { ExtensionManagerNodeTypeParams, NodeExtension, NodeExtensionSpec } from '@remirror/core';
+import { ExtensionManagerNodeTypeParams, KeyboardBindings,NodeExtension, NodeExtensionSpec } from '@remirror/core';
 import { chainCommands, exitCode } from 'prosemirror-commands';
 
 export class HardBreakExtension extends NodeExtension {
@@ -17,7 +17,7 @@ export class HardBreakExtension extends NodeExtension {
     };
   }
 
-  public keys({ type }: ExtensionManagerNodeTypeParams) {
+  public keys({ type }: ExtensionManagerNodeTypeParams):KeyboardBindings {
     const command = chainCommands(exitCode, (state, dispatch) => {
       if (dispatch) {
         dispatch(state.tr.replaceSelectionWith(type.create()).scrollIntoView());

--- a/@remirror/core-extensions/src/nodes/hard-break-extension.ts
+++ b/@remirror/core-extensions/src/nodes/hard-break-extension.ts
@@ -1,4 +1,9 @@
-import { ExtensionManagerNodeTypeParams, KeyboardBindings,NodeExtension, NodeExtensionSpec } from '@remirror/core';
+import {
+  ExtensionManagerNodeTypeParams,
+  KeyboardBindings,
+  NodeExtension,
+  NodeExtensionSpec,
+} from '@remirror/core';
 import { chainCommands, exitCode } from 'prosemirror-commands';
 
 export class HardBreakExtension extends NodeExtension {
@@ -17,7 +22,7 @@ export class HardBreakExtension extends NodeExtension {
     };
   }
 
-  public keys({ type }: ExtensionManagerNodeTypeParams):KeyboardBindings {
+  public keys({ type }: ExtensionManagerNodeTypeParams): KeyboardBindings {
     const command = chainCommands(exitCode, (state, dispatch) => {
       if (dispatch) {
         dispatch(state.tr.replaceSelectionWith(type.create()).scrollIntoView());

--- a/@remirror/core-extensions/src/nodes/heading-extension.ts
+++ b/@remirror/core-extensions/src/nodes/heading-extension.ts
@@ -3,6 +3,7 @@ import {
   CommandNodeTypeParams,
   ExtensionManagerNodeTypeParams,
   KeyboardBindings,
+  KeyboardBindings,
   NodeExtension,
   NodeExtensionOptions,
   NodeExtensionSpec,
@@ -76,7 +77,7 @@ export class HeadingExtension extends NodeExtension<HeadingExtensionOptions> {
     };
   }
 
-  public keys({ type }: ExtensionManagerNodeTypeParams) {
+  public keys({ type }: ExtensionManagerNodeTypeParams):KeyboardBindings {
     const keys: KeyboardBindings = Object.create(null);
 
     this.options.levels.forEach(level => {

--- a/@remirror/core-extensions/src/nodes/heading-extension.ts
+++ b/@remirror/core-extensions/src/nodes/heading-extension.ts
@@ -3,7 +3,6 @@ import {
   CommandNodeTypeParams,
   ExtensionManagerNodeTypeParams,
   KeyboardBindings,
-  KeyboardBindings,
   NodeExtension,
   NodeExtensionOptions,
   NodeExtensionSpec,

--- a/@remirror/core-extensions/src/nodes/heading-extension.ts
+++ b/@remirror/core-extensions/src/nodes/heading-extension.ts
@@ -77,7 +77,7 @@ export class HeadingExtension extends NodeExtension<HeadingExtensionOptions> {
     };
   }
 
-  public keys({ type }: ExtensionManagerNodeTypeParams):KeyboardBindings {
+  public keys({ type }: ExtensionManagerNodeTypeParams): KeyboardBindings {
     const keys: KeyboardBindings = Object.create(null);
 
     this.options.levels.forEach(level => {

--- a/@remirror/core-extensions/src/nodes/list-item-extension.ts
+++ b/@remirror/core-extensions/src/nodes/list-item-extension.ts
@@ -1,4 +1,9 @@
-import { ExtensionManagerNodeTypeParams, KeyboardBindings,NodeExtension, NodeExtensionSpec } from '@remirror/core';
+import {
+  ExtensionManagerNodeTypeParams,
+  KeyboardBindings,
+  NodeExtension,
+  NodeExtensionSpec,
+} from '@remirror/core';
 import { liftListItem, sinkListItem, splitListItem } from 'prosemirror-schema-list';
 
 export class ListItemExtension extends NodeExtension {
@@ -17,7 +22,7 @@ export class ListItemExtension extends NodeExtension {
     };
   }
 
-  public keys({ type }: ExtensionManagerNodeTypeParams) : KeyboardBindings{
+  public keys({ type }: ExtensionManagerNodeTypeParams): KeyboardBindings {
     return {
       Enter: splitListItem(type),
       Tab: sinkListItem(type),

--- a/@remirror/core-extensions/src/nodes/list-item-extension.ts
+++ b/@remirror/core-extensions/src/nodes/list-item-extension.ts
@@ -1,4 +1,4 @@
-import { ExtensionManagerNodeTypeParams, NodeExtension, NodeExtensionSpec } from '@remirror/core';
+import { ExtensionManagerNodeTypeParams, KeyboardBindings,NodeExtension, NodeExtensionSpec } from '@remirror/core';
 import { liftListItem, sinkListItem, splitListItem } from 'prosemirror-schema-list';
 
 export class ListItemExtension extends NodeExtension {
@@ -17,7 +17,7 @@ export class ListItemExtension extends NodeExtension {
     };
   }
 
-  public keys({ type }: ExtensionManagerNodeTypeParams) {
+  public keys({ type }: ExtensionManagerNodeTypeParams) : KeyboardBindings{
     return {
       Enter: splitListItem(type),
       Tab: sinkListItem(type),

--- a/@remirror/core-extensions/src/nodes/ordered-list-extension.ts
+++ b/@remirror/core-extensions/src/nodes/ordered-list-extension.ts
@@ -47,7 +47,7 @@ export class OrderedListExtension extends NodeExtension {
     return { toggleOrderedList: () => toggleList(type, schema.nodes.listItem) };
   }
 
-  public keys({ type, schema }: ExtensionManagerNodeTypeParams) : KeyboardBindings{
+  public keys({ type, schema }: ExtensionManagerNodeTypeParams): KeyboardBindings {
     return {
       'Shift-Ctrl-9': toggleList(type, schema.nodes.listItem),
     };

--- a/@remirror/core-extensions/src/nodes/ordered-list-extension.ts
+++ b/@remirror/core-extensions/src/nodes/ordered-list-extension.ts
@@ -2,6 +2,7 @@ import {
   CommandNodeTypeParams,
   ExtensionManagerNodeTypeParams,
   isElementDOMNode,
+  KeyboardBindings,
   NodeExtension,
   NodeExtensionSpec,
   NodeGroup,
@@ -46,7 +47,7 @@ export class OrderedListExtension extends NodeExtension {
     return { toggleOrderedList: () => toggleList(type, schema.nodes.listItem) };
   }
 
-  public keys({ type, schema }: ExtensionManagerNodeTypeParams) {
+  public keys({ type, schema }: ExtensionManagerNodeTypeParams) : KeyboardBindings{
     return {
       'Shift-Ctrl-9': toggleList(type, schema.nodes.listItem),
     };

--- a/@remirror/core-extensions/src/nodes/simple-code-block-extension.ts
+++ b/@remirror/core-extensions/src/nodes/simple-code-block-extension.ts
@@ -3,6 +3,7 @@ import {
   CommandNodeTypeParams,
   EDITOR_CLASS_SELECTOR,
   ExtensionManagerNodeTypeParams,
+  KeyboardBindings,
   NodeExtension,
   NodeExtensionSpec,
   NodeGroup,
@@ -33,7 +34,7 @@ export class CodeBlockExtension extends NodeExtension {
     return { toggleCodeBlock: () => toggleBlockItem({ type, toggleType: schema.nodes.paragraph }) };
   }
 
-  public keys({ type, schema }: ExtensionManagerNodeTypeParams) {
+  public keys({ type, schema }: ExtensionManagerNodeTypeParams): KeyboardBindings {
     return {
       'Shift-Ctrl-\\': toggleBlockItem({ type, toggleType: schema.nodes.paragraph }),
     };


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail and reference any issues it addresses-->


First of all, excellent project. I really appreciate the idea of `Extension`, where I can put ALL my logic of one node/mark into a single class. Greet improvement for the readability.  When I using remirror in my project, I found a TypeScript issue as described below:

----

I want to extend those exist extensions in remirror but only change the key method, like something below:

```typescript
class MyCodeBlockExtension extends CodeBlockExtension {
  public keys(): KeyboardBindings {
    return {
      somekey: something
    }
  }
}
```

However, TS stop me from do this, beacuse `CodeBlockExtension.keys` return `{'Shift-Ctrl-\\': CommandFunction<any>}`. `MyCodeBlockExtension` must follow this type since it's a subcalss of `CodeBlockExtension`. 

I can prevent this error by 1) copy code from `@remirror` instead of import them; 2) use TS `Exclude` type to remove the definition of `CodeBlockExtension.keys`; 3) stop TS from type checking this class. 

But I think the best solution is to tell TS that what `keys` want to return is any bindings as well as it's a `KeyboardBindings` instance instead of some specific key bindings.  This is just an update for TS type hitting and it shouldn't affect any actual feature.

BTW, other `Extension` methods (like `commands`) should also have this issue. I can submit another PR to fix them if you agree to my opinion.




## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/ifiokjr/remirror/blob/master/docs/contributing.md)
      document.
- [x] My code follows the code style of this project and `yarn fix` runs successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `yarn test` .

## Screenshots

<!-- Delete this section if not applicable -->

N/A
